### PR TITLE
feat: implement geocoding service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5457/fast_feet"
 # Auth
 JWT_PRIVATE_KEY=
 JWT_PUBLIC_KEY=
+
+# Nominatim Geocoding API
+NOMINATIM_API_URL="https://nominatim.openstreetmap.org"
+NOMINATIM_API_USER_AGENT="FastFeetAPI/1.0 (github.com/yourusername/fast-feet-api)"

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -48,3 +48,5 @@ jobs:
           JWT_PRIVATE_KEY: ${{ secrets.JWT_PRIVATE_KEY }}
           JWT_PUBLIC_KEY: ${{ secrets.JWT_PUBLIC_KEY }}
           DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/fast_feet'
+          NOMINATIM_API_URL: 'https://nominatim.openstreetmap.org'
+          NOMINATIM_API_USER_AGENT: 'FastFeet/1.0 (github.com/eduardozago/fast-feet)'

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:e2e": "vitest run --config ./vitest.config.e2e.ts"
   },
   "dependencies": {
+    "@nestjs/axios": "^4.0.1",
     "@nestjs/common": "^11.1.18",
     "@nestjs/config": "^4.0.3",
     "@nestjs/core": "^11.1.18",
@@ -29,6 +30,7 @@
     "@prisma/adapter-pg": "^7.7.0",
     "@prisma/client": "^7.7.0",
     "argon2": "^0.44.0",
+    "axios": "^1.15.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@nestjs/axios':
+        specifier: ^4.0.1
+        version: 4.0.1(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.15.0)(rxjs@7.8.2)
       '@nestjs/common':
         specifier: ^11.1.18
         version: 11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -35,6 +38,9 @@ importers:
       argon2:
         specifier: ^0.44.0
         version: 0.44.0
+      axios:
+        specifier: ^1.15.0
+        version: 1.15.0
       passport-jwt:
         specifier: ^4.0.1
         version: 4.0.1
@@ -742,6 +748,13 @@ packages:
   '@napi-rs/nice@1.1.1':
     resolution: {integrity: sha512-xJIPs+bYuc9ASBl+cvGsKbGrJmS6fAKaSZCnT0lhahT5rhA2VVy9/EcIgd2JhtEuFOJNx7UHNn/qiTPTY4nrQw==}
     engines: {node: '>= 10'}
+
+  '@nestjs/axios@4.0.1':
+    resolution: {integrity: sha512-68pFJgu+/AZbWkGu65Z3r55bTsCPlgyKaV4BSG8yUAD72q1PPuyVRgUwFv6BxdnibTUHlyxm06FmYWNC+bjN7A==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      axios: ^1.3.1
+      rxjs: ^7.0.0
 
   '@nestjs/cli@11.0.18':
     resolution: {integrity: sha512-z72OS+sFrDgIkNu/e/vUhbnjHZwAYQS8fBJKXLiFyz8059IVuY2FKebV2YMxyhY+920d4LX1hBIAGL5qQNdR7g==}
@@ -1678,6 +1691,9 @@ packages:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
 
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
     peerDependencies:
@@ -2321,6 +2337,15 @@ packages:
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -3157,6 +3182,10 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -4353,6 +4382,12 @@ snapshots:
       '@napi-rs/nice-win32-x64-msvc': 1.1.1
     optional: true
 
+  '@nestjs/axios@4.0.1(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.15.0)(rxjs@7.8.2)':
+    dependencies:
+      '@nestjs/common': 11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      axios: 1.15.0
+      rxjs: 7.8.2
+
   '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24)(chokidar@4.0.3))(@swc/core@1.15.24)(@types/node@25.5.2)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
@@ -5366,6 +5401,14 @@ snapshots:
 
   aws-ssl-profiles@1.1.2: {}
 
+  axios@1.15.0:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+
   b4a@1.8.0: {}
 
   balanced-match@1.0.2: {}
@@ -6070,6 +6113,8 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.4.2: {}
+
+  follow-redirects@1.15.11: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -6865,6 +6910,8 @@ snapshots:
       ipaddr.js: 1.9.1
     optional: true
 
+  proxy-from-env@2.1.0: {}
+
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
@@ -6974,7 +7021,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
     optional: true

--- a/prisma/migrations/20260412001348_add_cordinates_to_recipient_addresses/migration.sql
+++ b/prisma/migrations/20260412001348_add_cordinates_to_recipient_addresses/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - Added the required column `latitude` to the `recipient_addresses` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `longitude` to the `recipient_addresses` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "recipient_addresses" ADD COLUMN     "latitude" DECIMAL(8,6) NOT NULL,
+ADD COLUMN     "longitude" DECIMAL(9,6) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -84,6 +84,8 @@ model RecipientAddress {
   state        String
   country      String
   postalCode   String    @map("postal_code")
+  latitude     Decimal   @db.Decimal(8, 6)
+  longitude    Decimal   @db.Decimal(9, 6)
   createdAt    DateTime  @default(now()) @map("created_at")
   updatedAt    DateTime? @updatedAt @map("updated_at")
 

--- a/src/domain/delivery/application/location/geocoding-service.ts
+++ b/src/domain/delivery/application/location/geocoding-service.ts
@@ -1,0 +1,23 @@
+import { Either } from '@/core/either'
+import { GeocodingServiceError } from '../use-cases/errors/geocoding-service-error'
+
+export interface GeocodingAddress {
+  street: string
+  number: string
+  neighborhood: string
+  city: string
+  state: string
+  country: string
+  postalCode: string
+}
+
+export interface GeocodingResult {
+  latitude: number
+  longitude: number
+}
+
+export abstract class GeocodingService {
+  abstract geocode(
+    address: GeocodingAddress,
+  ): Promise<Either<GeocodingServiceError, GeocodingResult>>
+}

--- a/src/domain/delivery/application/use-cases/errors/geocoding-service-error.ts
+++ b/src/domain/delivery/application/use-cases/errors/geocoding-service-error.ts
@@ -1,0 +1,7 @@
+import { UseCaseError } from '@/core/errors/use-case-error'
+
+export class GeocodingServiceError extends Error implements UseCaseError {
+  constructor() {
+    super('Could not geocode the provided address.')
+  }
+}

--- a/src/domain/delivery/application/use-cases/errors/geocoding-service-error.ts
+++ b/src/domain/delivery/application/use-cases/errors/geocoding-service-error.ts
@@ -1,7 +1,31 @@
 import { UseCaseError } from '@/core/errors/use-case-error'
 
 export class GeocodingServiceError extends Error implements UseCaseError {
+  constructor(message: string) {
+    super(message)
+  }
+}
+
+export class GeocodingNetworkError extends GeocodingServiceError {
+  constructor(message = 'Network error during geocoding') {
+    super(message)
+  }
+}
+
+export class GeocodingInvalidResponseError extends GeocodingServiceError {
   constructor() {
-    super('Could not geocode the provided address.')
+    super('Invalid response from geocoding service')
+  }
+}
+
+export class GeocodingConfigurationError extends GeocodingServiceError {
+  constructor() {
+    super('Geocoding service misconfigured')
+  }
+}
+
+export class GeocodingUnknownError extends GeocodingServiceError {
+  constructor() {
+    super('Geocoding service unknown error')
   }
 }

--- a/src/domain/delivery/application/use-cases/errors/geocoding-service-error.ts
+++ b/src/domain/delivery/application/use-cases/errors/geocoding-service-error.ts
@@ -6,12 +6,6 @@ export class GeocodingServiceError extends Error implements UseCaseError {
   }
 }
 
-export class GeocodingNetworkError extends GeocodingServiceError {
-  constructor(message = 'Network error during geocoding') {
-    super(message)
-  }
-}
-
 export class GeocodingInvalidResponseError extends GeocodingServiceError {
   constructor() {
     super('Invalid response from geocoding service')

--- a/src/domain/delivery/application/use-cases/recipient/create-recipient-address.spec.ts
+++ b/src/domain/delivery/application/use-cases/recipient/create-recipient-address.spec.ts
@@ -3,18 +3,23 @@ import { makeRecipient } from 'test/factories/delivery/make-recipient'
 import { InMemoryRecipientAddressesRepository } from 'test/repositories/delivery/in-memory-recipient-addresses-repository'
 import { CreateRecipientAddressUseCase } from './create-recipient-address'
 import { RecipientNotFoundError } from './errors/recipient-not-found-error'
+import { FakeGeocodingService } from 'test/location/fake-geocoding-service'
+import { GeocodingServiceError } from '../errors/geocoding-service-error'
 
 let recipientAdressesRepository: InMemoryRecipientAddressesRepository
 let recipientsRepository: InMemoryRecipientsRepository
+let geocodingService: FakeGeocodingService
 let sut: CreateRecipientAddressUseCase
 
 describe('Create Recipient Address', () => {
   beforeEach(() => {
     recipientAdressesRepository = new InMemoryRecipientAddressesRepository()
     recipientsRepository = new InMemoryRecipientsRepository()
+    geocodingService = new FakeGeocodingService()
     sut = new CreateRecipientAddressUseCase(
       recipientAdressesRepository,
       recipientsRepository,
+      geocodingService,
     )
   })
 
@@ -67,5 +72,29 @@ describe('Create Recipient Address', () => {
     expect(result.isLeft()).toBe(true)
     expect(result.value).toBeInstanceOf(RecipientNotFoundError)
     expect(recipientAdressesRepository.items).toHaveLength(0)
+  })
+
+  it('should not be able to create a recipient address if geocoding fails', async () => {
+    const recipient = makeRecipient()
+    await recipientsRepository.create(recipient)
+
+    // Force geocoding to fail
+    geocodingService.shouldFail = true
+
+    const result = await sut.execute({
+      recipientId: recipient.id.toString(),
+      street: 'Street 1',
+      number: '123',
+      complement: 'Complement 1',
+      neighborhood: 'Neighborhood 1',
+      city: 'City 1',
+      state: 'State 1',
+      postalCode: '12345-678',
+      country: 'Country 1',
+    })
+
+    expect(result.isLeft()).toBe(true)
+    expect(recipientAdressesRepository.items).toHaveLength(0)
+    expect(result.value).toBeInstanceOf(GeocodingServiceError)
   })
 })

--- a/src/domain/delivery/application/use-cases/recipient/create-recipient-address.ts
+++ b/src/domain/delivery/application/use-cases/recipient/create-recipient-address.ts
@@ -5,6 +5,8 @@ import { UniqueEntityID } from '@/core/entities/unique-entity-id'
 import { RecipientAddressesRepository } from '../../repositories/recipient-addresses-repository'
 import { RecipientsRepository } from '../../repositories/recipients-repository'
 import { RecipientNotFoundError } from './errors/recipient-not-found-error'
+import { GeocodingService } from '../../location/geocoding-service'
+import { GeocodingServiceError } from '../errors/geocoding-service-error'
 
 interface CreateRecipientAddressUseCaseRequest {
   recipientId: string
@@ -19,7 +21,7 @@ interface CreateRecipientAddressUseCaseRequest {
 }
 
 export type CreateRecipientAddressUseCaseResponse = Either<
-  RecipientNotFoundError,
+  RecipientNotFoundError | GeocodingServiceError,
   {
     recipientAddress: RecipientAddress
   }
@@ -30,6 +32,7 @@ export class CreateRecipientAddressUseCase {
   constructor(
     private recipientAddressesRepository: RecipientAddressesRepository,
     private recipientsRepository: RecipientsRepository,
+    private geocodingService: GeocodingService,
   ) {}
 
   async execute({
@@ -49,6 +52,22 @@ export class CreateRecipientAddressUseCase {
       return left(new RecipientNotFoundError())
     }
 
+    const geocodingResult = await this.geocodingService.geocode({
+      street,
+      number,
+      neighborhood,
+      city,
+      state,
+      country,
+      postalCode,
+    })
+
+    if (geocodingResult.isLeft()) {
+      return left(geocodingResult.value)
+    }
+
+    const { latitude, longitude } = geocodingResult.value
+
     const recipientAddress = RecipientAddress.create({
       recipientId: new UniqueEntityID(recipientId),
       street,
@@ -59,6 +78,8 @@ export class CreateRecipientAddressUseCase {
       state,
       country,
       postalCode,
+      latitude,
+      longitude,
     })
 
     await this.recipientAddressesRepository.create(recipientAddress)

--- a/src/domain/delivery/enterprise/entities/recipient-address.ts
+++ b/src/domain/delivery/enterprise/entities/recipient-address.ts
@@ -12,6 +12,8 @@ export interface RecipientAddressProps {
   state: string
   country: string
   postalCode: string
+  latitude: number
+  longitude: number
   createdAt: Date
   updatedAt?: Date | null
 }
@@ -51,6 +53,14 @@ export class RecipientAddress extends Entity<RecipientAddressProps> {
 
   get postalCode() {
     return this.props.postalCode
+  }
+
+  get latitude() {
+    return this.props.latitude
+  }
+
+  get longitude() {
+    return this.props.longitude
   }
 
   get createdAt() {

--- a/src/infra/database/prisma/mappers/delivery/prisma-recipient-address-mapper.ts
+++ b/src/infra/database/prisma/mappers/delivery/prisma-recipient-address-mapper.ts
@@ -6,6 +6,10 @@ import {
 } from 'generated/prisma/client'
 
 export class PrismaRecipientAddressMapper {
+  private static parseDecimal(raw: Prisma.Decimal) {
+    return Number(raw)
+  }
+
   static toDomain(raw: PrismaRecipientAddress) {
     return RecipientAddress.create(
       {
@@ -18,6 +22,8 @@ export class PrismaRecipientAddressMapper {
         state: raw.state,
         country: raw.country,
         postalCode: raw.postalCode,
+        latitude: this.parseDecimal(raw.latitude),
+        longitude: this.parseDecimal(raw.longitude),
         createdAt: raw.createdAt,
         updatedAt: raw.updatedAt,
       },
@@ -39,6 +45,8 @@ export class PrismaRecipientAddressMapper {
       state: recipientAddress.state,
       country: recipientAddress.country,
       postalCode: recipientAddress.postalCode,
+      latitude: recipientAddress.latitude,
+      longitude: recipientAddress.longitude,
       createdAt: recipientAddress.createdAt,
       updatedAt: recipientAddress.updatedAt,
     }

--- a/src/infra/env/env.ts
+++ b/src/infra/env/env.ts
@@ -5,6 +5,8 @@ export const envSchema = z.object({
   JWT_PRIVATE_KEY: z.string(),
   JWT_PUBLIC_KEY: z.string(),
   PORT: z.coerce.number().optional().default(3333),
+  NOMINATIM_API_URL: z.string().url(),
+  NOMINATIM_API_USER_AGENT: z.string(),
 })
 
 export type Env = z.infer<typeof envSchema>

--- a/src/infra/http/controllers/delivery/recipient/create-recipient-address.controller.e2e-spec.ts
+++ b/src/infra/http/controllers/delivery/recipient/create-recipient-address.controller.e2e-spec.ts
@@ -1,4 +1,5 @@
 import { AppModule } from '@/app.module'
+import { GeocodingService } from '@/domain/delivery/application/location/geocoding-service'
 import { DatabaseModule } from '@/infra/database/database.module'
 import { PrismaService } from '@/infra/database/prisma/prisma.service'
 import { JwtService } from '@nestjs/jwt'
@@ -11,6 +12,7 @@ import request from 'supertest'
 import { RecipientFactory } from 'test/factories/delivery/make-recipient'
 import { makeRecipientAddress } from 'test/factories/delivery/make-recipient-address'
 import { AccountFactory } from 'test/factories/identity/make-account'
+import { FakeGeocodingService } from 'test/location/fake-geocoding-service'
 import { PrismaServiceE2E } from 'test/prisma-service-e2e'
 
 describe('Create Recipient Address (E2E)', () => {
@@ -27,6 +29,8 @@ describe('Create Recipient Address (E2E)', () => {
     })
       .overrideProvider(PrismaService)
       .useClass(PrismaServiceE2E)
+      .overrideProvider(GeocodingService)
+      .useClass(FakeGeocodingService)
       .compile()
 
     app = moduleRef.createNestApplication<NestFastifyApplication>(

--- a/src/infra/http/http.module.ts
+++ b/src/infra/http/http.module.ts
@@ -30,9 +30,10 @@ import { CompleteDeliveryController } from './controllers/delivery/delivery/comp
 import { CompleteDeliveryUseCase } from '@/domain/delivery/application/use-cases/delivery/complete-delivery'
 import { DeleteDeliveryController } from './controllers/delivery/delivery/delete-delivery.controller'
 import { DeleteDeliveryUseCase } from '@/domain/delivery/application/use-cases/delivery/delete-delivery'
+import { LocationModule } from '../location/location.module'
 
 @Module({
-  imports: [DatabaseModule, CryptographyModule, GatewaysModule],
+  imports: [DatabaseModule, CryptographyModule, GatewaysModule, LocationModule],
   controllers: [
     // Identity
     CreateAccountController,

--- a/src/infra/location/location.module.ts
+++ b/src/infra/location/location.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common'
+import { HttpModule } from '@nestjs/axios'
+import { NominatimGeocodingService } from './nominatim-geocoding-service'
+import { GeocodingService } from '@/domain/delivery/application/location/geocoding-service'
+import { EnvModule } from '../env/env.module'
+
+@Module({
+  imports: [HttpModule, EnvModule],
+  providers: [
+    {
+      provide: GeocodingService,
+      useClass: NominatimGeocodingService,
+    },
+  ],
+  exports: [GeocodingService],
+})
+export class LocationModule {}

--- a/src/infra/location/nominatim-geocoding-service.ts
+++ b/src/infra/location/nominatim-geocoding-service.ts
@@ -1,0 +1,164 @@
+import {
+  GeocodingAddress,
+  GeocodingResult,
+  GeocodingService,
+} from '@/domain/delivery/application/location/geocoding-service'
+import { Either, left, right } from '@/core/either'
+import {
+  GeocodingConfigurationError,
+  GeocodingInvalidResponseError,
+  GeocodingServiceError,
+  GeocodingUnknownError,
+} from '@/domain/delivery/application/use-cases/errors/geocoding-service-error'
+import { HttpService } from '@nestjs/axios'
+import { catchError, firstValueFrom, map, of, timeout } from 'rxjs'
+import { Injectable, Logger } from '@nestjs/common'
+import { EnvService } from '../env/env.service'
+import { AxiosError } from 'axios'
+
+interface NominatimGeocodingResponse {
+  type: string
+  features: Array<{
+    geometry: {
+      type: string
+      coordinates: [number, number]
+    }
+  }>
+}
+
+@Injectable()
+export class NominatimGeocodingService implements GeocodingService {
+  private logger = new Logger(NominatimGeocodingService.name)
+  private REQUEST_TIMEOUT = 10000
+
+  constructor(
+    private httpService: HttpService,
+    private envService: EnvService,
+  ) {}
+
+  async geocode(
+    address: GeocodingAddress,
+  ): Promise<Either<GeocodingServiceError, GeocodingResult>> {
+    const formattedAddress = this.formatAddress(address)
+
+    const baseUrl = this.envService.get('NOMINATIM_API_URL')
+
+    if (!baseUrl) {
+      return left(new GeocodingConfigurationError())
+    }
+
+    const format = 'geojson'
+
+    const userAgent =
+      this.envService.get('NOMINATIM_API_USER_AGENT') ?? 'FastFeet/1.0'
+
+    const response: Either<GeocodingServiceError, GeocodingResult> =
+      await firstValueFrom(
+        this.httpService
+          .get<NominatimGeocodingResponse>(
+            `${baseUrl}/search?q=${formattedAddress}&format=${format}`,
+            {
+              headers: {
+                'User-Agent': userAgent,
+                'Content-Type': 'application/json',
+              },
+              timeout: this.REQUEST_TIMEOUT,
+            },
+          )
+          .pipe(
+            timeout(this.REQUEST_TIMEOUT),
+            map((response) => this.validateAndExtract(response.data, address)),
+            catchError((error) => of(this.handleError(error, address))),
+          ),
+      )
+
+    return response
+  }
+
+  private normalizeField(value: string): string {
+    return value
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .trim()
+      .replace(/\s+/g, '+')
+  }
+
+  private formatAddress(address: GeocodingAddress): string {
+    return [
+      `${this.normalizeField(address.street)}+${this.normalizeField(address.number)}`,
+      this.normalizeField(address.city),
+      this.normalizeField(address.state),
+      this.normalizeField(address.postalCode),
+      this.normalizeField(address.country),
+    ].join(',+')
+  }
+
+  private validateAndExtract(
+    data: NominatimGeocodingResponse,
+    address: GeocodingAddress,
+  ): Either<GeocodingServiceError, GeocodingResult> {
+    if (!data?.features || !Array.isArray(data.features)) {
+      this.logger.warn(
+        { response: data },
+        'Invalid geocoding response structure',
+      )
+      return left(new GeocodingInvalidResponseError())
+    }
+
+    if (data.features.length === 0) {
+      this.logger.debug({ address }, 'No geocoding results found')
+
+      return left(new GeocodingInvalidResponseError())
+    }
+
+    const feature = data.features[0]
+
+    if (
+      !feature.geometry?.coordinates ||
+      feature.geometry.coordinates.length !== 2
+    ) {
+      this.logger.warn({ feature }, 'Missing coordinates in geocoding response')
+
+      return left(new GeocodingInvalidResponseError())
+    }
+
+    const [longitude, latitude] = feature.geometry.coordinates
+
+    if (isNaN(latitude) || isNaN(longitude)) {
+      return left(new GeocodingInvalidResponseError())
+    }
+
+    return right({ latitude, longitude })
+  }
+
+  private handleError(
+    error: unknown,
+    address: GeocodingAddress,
+  ): Either<GeocodingServiceError, GeocodingResult> {
+    if (error instanceof AxiosError) {
+      const status = error.response?.status
+
+      if (status && status >= 400 && status < 500) {
+        this.logger.warn(
+          { status, address: `${address.street}, ${address.city}` },
+          'Geocoding client error',
+        )
+        return left(new GeocodingServiceError(`Client error: ${status}`))
+      }
+
+      if (status && status >= 500) {
+        this.logger.error(
+          { status, address: `${address.street}, ${address.city}` },
+          'Geocoding server error',
+        )
+        return left(new GeocodingServiceError('Geocoding service unavailable'))
+      }
+
+      this.logger.error({ error }, 'Geocoding unknown error')
+      return left(new GeocodingUnknownError())
+    }
+
+    this.logger.error({ error }, 'Unexpected geocoding error')
+    return left(new GeocodingUnknownError())
+  }
+}

--- a/test/factories/delivery/make-recipient-address.ts
+++ b/test/factories/delivery/make-recipient-address.ts
@@ -22,6 +22,8 @@ export function makeRecipientAddress(
       state: faker.location.state(),
       country: faker.location.country(),
       postalCode: faker.location.zipCode(),
+      latitude: faker.location.latitude(),
+      longitude: faker.location.longitude(),
       ...override,
     },
     id,

--- a/test/location/fake-geocoding-service.ts
+++ b/test/location/fake-geocoding-service.ts
@@ -1,0 +1,29 @@
+import {
+  GeocodingAddress,
+  GeocodingResult,
+  GeocodingService,
+} from '@/domain/delivery/application/location/geocoding-service'
+import { Either, left, right } from '@/core/either'
+import { GeocodingServiceError } from '@/domain/delivery/application/use-cases/errors/geocoding-service-error'
+import { faker } from '@faker-js/faker'
+
+export class FakeGeocodingService implements GeocodingService {
+  shouldFail = false
+
+  geocode(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    address: GeocodingAddress,
+  ): Promise<Either<GeocodingServiceError, GeocodingResult>> {
+    if (this.shouldFail) {
+      this.shouldFail = false
+      return Promise.resolve(left(new GeocodingServiceError()))
+    }
+
+    return Promise.resolve(
+      right({
+        latitude: faker.location.latitude(),
+        longitude: faker.location.longitude(),
+      }),
+    )
+  }
+}


### PR DESCRIPTION
## Description

Implements geocoding service integration to automatically fetch and store latitude/longitude coordinates when creating recipient addresses. Uses Nominatim (OpenStreetMap) as the geocoding provider.

**Key Changes:**
- Added `GeocodingService` abstract class and `NominatimGeocodingService` implementation
- Added `LocationModule` for dependency injection
- Extended `RecipientAddress` entity with `latitude` and `longitude` fields
- Updated `CreateRecipientAddressUseCase` to fetch coordinates via geocoding service
- Added geocoding error handling with specific error types
- Updated environment configuration for Nominatim API settings
- Added `FakeGeocodingService` for testing
- Updated Prisma schema and mapper to include coordinate columns

## Type of Change

- [x] Feature (new functionality)

## Branch

- **Source:** `feat/geocoding`
- **Target:** `develop`

## Checklist

- [x] Code follows project standards
- [x] Tests added/updated (unit tests for geocoding integration and fake service)
- [x] Documentation updated (environment example file updated with Nominatim config)
- [x] Self-reviewed the code

---
