### PR TITLE
refactor(recipient): Nest address routes and add ownership validation

### DIFF
--- a/src/domain/delivery/application/use-cases/recipient/delete-recipient-address.spec.ts
+++ b/src/domain/delivery/application/use-cases/recipient/delete-recipient-address.spec.ts
@@ -1,6 +1,8 @@
 import { InMemoryRecipientAddressesRepository } from 'test/repositories/delivery/in-memory-recipient-addresses-repository'
 import { DeleteRecipientAddressUseCase } from './delete-recipient-address'
 import { makeRecipientAddress } from 'test/factories/delivery/make-recipient-address'
+import { RecipientAddressNotFoundError } from './errors/recipient-address-not-found-error'
+import { UniqueEntityID } from '@/core/entities/unique-entity-id'
 
 let recipientAddressesRepository: InMemoryRecipientAddressesRepository
 let sut: DeleteRecipientAddressUseCase
@@ -12,7 +14,9 @@ describe('Delete Recipient Address', () => {
   })
 
   it('should be able to delete a recipient address', async () => {
+    const recipientId = new UniqueEntityID()
     const recipientAddress = makeRecipientAddress({
+      recipientId,
       street: 'Street 1',
       number: '1',
       neighborhood: 'Neighborhood 1',
@@ -24,10 +28,27 @@ describe('Delete Recipient Address', () => {
     await recipientAddressesRepository.create(recipientAddress)
 
     const result = await sut.execute({
+      recipientId: recipientId.toString(),
       recipientAddressId: recipientAddress.id.toString(),
     })
 
     expect(result.isRight()).toBe(true)
     expect(recipientAddressesRepository.items).toHaveLength(0)
+  })
+
+  it('should not be able to delete an address that does not belong to the recipient', async () => {
+    const recipientAddress = makeRecipientAddress({
+      recipientId: new UniqueEntityID('recipient-1'),
+    })
+    await recipientAddressesRepository.create(recipientAddress)
+
+    const result = await sut.execute({
+      recipientId: 'recipient-2',
+      recipientAddressId: recipientAddress.id.toString(),
+    })
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.value).toBeInstanceOf(RecipientAddressNotFoundError)
+    expect(recipientAddressesRepository.items).toHaveLength(1)
   })
 })

--- a/src/domain/delivery/application/use-cases/recipient/delete-recipient-address.ts
+++ b/src/domain/delivery/application/use-cases/recipient/delete-recipient-address.ts
@@ -4,6 +4,7 @@ import { RecipientAddressesRepository } from '../../repositories/recipient-addre
 import { RecipientAddressNotFoundError } from './errors/recipient-address-not-found-error'
 
 interface DeleteRecipientAddressUseCaseRequest {
+  recipientId: string
   recipientAddressId: string
 }
 
@@ -19,12 +20,17 @@ export class DeleteRecipientAddressUseCase {
   ) {}
 
   async execute({
+    recipientId,
     recipientAddressId,
   }: DeleteRecipientAddressUseCaseRequest): Promise<DeleteRecipientAddressUseCaseResponse> {
     const recipientAddress =
       await this.recipientAddressesRepository.findById(recipientAddressId)
 
     if (!recipientAddress) {
+      return left(new RecipientAddressNotFoundError())
+    }
+
+    if (recipientAddress.recipientId.toString() !== recipientId) {
       return left(new RecipientAddressNotFoundError())
     }
 

--- a/src/domain/delivery/application/use-cases/recipient/update-recipient-address.spec.ts
+++ b/src/domain/delivery/application/use-cases/recipient/update-recipient-address.spec.ts
@@ -1,17 +1,26 @@
 import { InMemoryRecipientAddressesRepository } from 'test/repositories/delivery/in-memory-recipient-addresses-repository'
 import { UpdateRecipientAddressUseCase } from './update-recipient-address'
 import { makeRecipientAddress } from 'test/factories/delivery/make-recipient-address'
+import { FakeGeocodingService } from 'test/location/fake-geocoding-service'
+import { GeocodingServiceError } from '../errors/geocoding-service-error'
+import { RecipientAddressNotFoundError } from './errors/recipient-address-not-found-error'
+import { UniqueEntityID } from '@/core/entities/unique-entity-id'
 
 let recipientAddressesRepository: InMemoryRecipientAddressesRepository
+let geocodingService: FakeGeocodingService
 let sut: UpdateRecipientAddressUseCase
 
 describe('Update Recipient Address', () => {
   beforeEach(() => {
     recipientAddressesRepository = new InMemoryRecipientAddressesRepository()
-    sut = new UpdateRecipientAddressUseCase(recipientAddressesRepository)
+    geocodingService = new FakeGeocodingService()
+    sut = new UpdateRecipientAddressUseCase(
+      recipientAddressesRepository,
+      geocodingService,
+    )
   })
 
-  it('should be able to update a recipient', async () => {
+  it('should be able to update a recipient address', async () => {
     const recipientAddress = makeRecipientAddress({
       street: 'Street 1',
       number: '1',
@@ -24,6 +33,7 @@ describe('Update Recipient Address', () => {
     await recipientAddressesRepository.create(recipientAddress)
 
     const result = await sut.execute({
+      recipientId: recipientAddress.recipientId.toString(),
       recipientAddressId: recipientAddress.id.toString(),
       street: 'Street 2',
       number: '2',
@@ -47,5 +57,57 @@ describe('Update Recipient Address', () => {
         postalCode: '87654-321',
       }),
     )
+    expect(recipientAddressesRepository.items[0].latitude).toBeDefined()
+    expect(recipientAddressesRepository.items[0].longitude).toBeDefined()
+  })
+
+  it('should not be able to update an address that does not belong to the recipient', async () => {
+    const recipientAddress = makeRecipientAddress({
+      recipientId: new UniqueEntityID('recipient-1'),
+    })
+    await recipientAddressesRepository.create(recipientAddress)
+
+    const result = await sut.execute({
+      recipientId: 'recipient-2',
+      recipientAddressId: recipientAddress.id.toString(),
+      street: 'Street 2',
+      number: '2',
+      neighborhood: 'Neighborhood 2',
+      city: 'City 2',
+      state: 'State 2',
+      country: 'Country 2',
+      postalCode: '87654-321',
+    })
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.value).toBeInstanceOf(RecipientAddressNotFoundError)
+    expect(recipientAddressesRepository.items[0].street).not.toBe('Street 2')
+  })
+
+  it('should not be able to update an address if geocoding fails', async () => {
+    const recipientId = new UniqueEntityID()
+    const recipientAddress = makeRecipientAddress({
+      recipientId,
+      street: 'Street 1',
+    })
+    await recipientAddressesRepository.create(recipientAddress)
+
+    geocodingService.shouldFail = true
+
+    const result = await sut.execute({
+      recipientId: recipientId.toString(),
+      recipientAddressId: recipientAddress.id.toString(),
+      street: 'Street 2',
+      number: '2',
+      neighborhood: 'Neighborhood 2',
+      city: 'City 2',
+      state: 'State 2',
+      country: 'Country 2',
+      postalCode: '87654-321',
+    })
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.value).toBeInstanceOf(GeocodingServiceError)
+    expect(recipientAddressesRepository.items[0].street).toBe('Street 1')
   })
 })

--- a/src/domain/delivery/application/use-cases/recipient/update-recipient-address.ts
+++ b/src/domain/delivery/application/use-cases/recipient/update-recipient-address.ts
@@ -1,10 +1,12 @@
 import { Either, left, right } from '@/core/either'
 import { Injectable } from '@nestjs/common'
-import { RecipientAddress } from '@/domain/delivery/enterprise/entities/recipient-address'
 import { RecipientAddressesRepository } from '../../repositories/recipient-addresses-repository'
 import { RecipientAddressNotFoundError } from './errors/recipient-address-not-found-error'
+import { GeocodingService } from '../../location/geocoding-service'
+import { GeocodingServiceError } from '../errors/geocoding-service-error'
 
 interface UpdateRecipientAddressUseCaseRequest {
+  recipientId: string
   recipientAddressId: string
   street: string
   number: string
@@ -17,19 +19,19 @@ interface UpdateRecipientAddressUseCaseRequest {
 }
 
 export type UpdateRecipientAddressUseCaseResponse = Either<
-  RecipientAddressNotFoundError,
-  {
-    recipientAddress: RecipientAddress
-  }
+  RecipientAddressNotFoundError | GeocodingServiceError,
+  null
 >
 
 @Injectable()
 export class UpdateRecipientAddressUseCase {
   constructor(
     private recipientAddressesRepository: RecipientAddressesRepository,
+    private geocodingService: GeocodingService,
   ) {}
 
   async execute({
+    recipientId,
     recipientAddressId,
     street,
     number,
@@ -47,6 +49,26 @@ export class UpdateRecipientAddressUseCase {
       return left(new RecipientAddressNotFoundError())
     }
 
+    if (recipientAddress.recipientId.toString() !== recipientId) {
+      return left(new RecipientAddressNotFoundError())
+    }
+
+    const geocodingResult = await this.geocodingService.geocode({
+      street,
+      number,
+      neighborhood,
+      city,
+      state,
+      country,
+      postalCode,
+    })
+
+    if (geocodingResult.isLeft()) {
+      return left(geocodingResult.value)
+    }
+
+    const { latitude, longitude } = geocodingResult.value
+
     recipientAddress.street = street
     recipientAddress.number = number
     recipientAddress.neighborhood = neighborhood
@@ -55,11 +77,11 @@ export class UpdateRecipientAddressUseCase {
     recipientAddress.state = state
     recipientAddress.country = country
     recipientAddress.postalCode = postalCode
+    recipientAddress.latitude = latitude
+    recipientAddress.longitude = longitude
 
     await this.recipientAddressesRepository.update(recipientAddress)
 
-    return right({
-      recipientAddress,
-    })
+    return right(null)
   }
 }

--- a/src/domain/delivery/enterprise/entities/recipient-address.ts
+++ b/src/domain/delivery/enterprise/entities/recipient-address.ts
@@ -103,6 +103,14 @@ export class RecipientAddress extends Entity<RecipientAddressProps> {
     this.props.postalCode = postalCode
   }
 
+  set latitude(latitude: number) {
+    this.props.latitude = latitude
+  }
+
+  set longitude(longitude: number) {
+    this.props.longitude = longitude
+  }
+
   static create(
     props: Optional<RecipientAddressProps, 'createdAt'>,
     id?: UniqueEntityID,

--- a/src/infra/http/controllers/delivery/recipient/create-recipient-address.controller.e2e-spec.ts
+++ b/src/infra/http/controllers/delivery/recipient/create-recipient-address.controller.e2e-spec.ts
@@ -48,7 +48,7 @@ describe('Create Recipient Address (E2E)', () => {
     await app.getHttpAdapter().getInstance().ready()
   })
 
-  test('[POST] /recipients/addresses', async () => {
+  test('[POST] /recipients/:recipientId/addresses', async () => {
     const account = await accountFactory.makePrismaAccount({
       email: 'johndoe@example.com',
       role: 'ADMIN',
@@ -66,10 +66,9 @@ describe('Create Recipient Address (E2E)', () => {
     })
 
     const response = await request(app.getHttpServer())
-      .post('/recipients/addresses')
+      .post(`/recipients/${recipient.id.toString()}/addresses`)
       .set('Authorization', `Bearer ${accessToken}`)
       .send({
-        recipientId: recipient.id.toString(),
         street: address.street,
         number: address.number,
         complement: address.complement,

--- a/src/infra/http/controllers/delivery/recipient/create-recipient-address.controller.ts
+++ b/src/infra/http/controllers/delivery/recipient/create-recipient-address.controller.ts
@@ -1,7 +1,8 @@
 import {
-  BadRequestException,
+  BadGatewayException,
   Body,
   Controller,
+  InternalServerErrorException,
   NotFoundException,
   Param,
   Post,
@@ -11,6 +12,10 @@ import { ZodValidationPipe } from '../../../pipes/zod-validation-pipe'
 import { Roles } from '@/infra/auth/roles.decorator'
 import { CreateRecipientAddressUseCase } from '@/domain/delivery/application/use-cases/recipient/create-recipient-address'
 import { RecipientNotFoundError } from '@/domain/delivery/application/use-cases/recipient/errors/recipient-not-found-error'
+import {
+  GeocodingConfigurationError,
+  GeocodingInvalidResponseError,
+} from '@/domain/delivery/application/use-cases/errors/geocoding-service-error'
 
 const createRecipientAddressBodySchema = z.object({
   street: z.string(),
@@ -66,12 +71,19 @@ export class CreateRecipientAddressController {
     if (result.isLeft()) {
       const error = result.value
 
-      switch (error.constructor) {
-        case RecipientNotFoundError:
-          throw new NotFoundException(error.message)
-        default:
-          throw new BadRequestException(error.message)
+      if (error instanceof RecipientNotFoundError) {
+        throw new NotFoundException(error.message)
       }
+
+      if (error instanceof GeocodingConfigurationError) {
+        throw new InternalServerErrorException(error.message)
+      }
+
+      if (error instanceof GeocodingInvalidResponseError) {
+        throw new BadGatewayException(error.message)
+      }
+
+      throw new InternalServerErrorException(error.message)
     }
   }
 }

--- a/src/infra/http/controllers/delivery/recipient/create-recipient-address.controller.ts
+++ b/src/infra/http/controllers/delivery/recipient/create-recipient-address.controller.ts
@@ -3,8 +3,8 @@ import {
   Body,
   Controller,
   NotFoundException,
+  Param,
   Post,
-  UsePipes,
 } from '@nestjs/common'
 import z from 'zod'
 import { ZodValidationPipe } from '../../../pipes/zod-validation-pipe'
@@ -13,7 +13,6 @@ import { CreateRecipientAddressUseCase } from '@/domain/delivery/application/use
 import { RecipientNotFoundError } from '@/domain/delivery/application/use-cases/recipient/errors/recipient-not-found-error'
 
 const createRecipientAddressBodySchema = z.object({
-  recipientId: z.string().uuid(),
   street: z.string(),
   number: z.string(),
   neighborhood: z.string(),
@@ -29,17 +28,19 @@ type CreateRecipientAddressBodySchema = z.infer<
 >
 
 @Controller()
-@UsePipes(new ZodValidationPipe(createRecipientAddressBodySchema))
 export class CreateRecipientAddressController {
   constructor(
     private createRecipientAddressUseCase: CreateRecipientAddressUseCase,
   ) {}
 
-  @Post('/recipients/addresses')
+  @Post('/recipients/:recipientId/addresses')
   @Roles('ADMIN')
-  async handle(@Body() body: CreateRecipientAddressBodySchema) {
+  async handle(
+    @Param('recipientId') recipientId: string,
+    @Body(new ZodValidationPipe(createRecipientAddressBodySchema))
+    body: CreateRecipientAddressBodySchema,
+  ) {
     const {
-      recipientId,
       street,
       number,
       neighborhood,

--- a/src/infra/http/controllers/delivery/recipient/delete-recipient-address.controller.e2e-spec.ts
+++ b/src/infra/http/controllers/delivery/recipient/delete-recipient-address.controller.e2e-spec.ts
@@ -46,7 +46,7 @@ describe('Delete Recipient Address (E2E)', () => {
     await app.getHttpAdapter().getInstance().ready()
   })
 
-  test('[DELETE] /recipients/addresses/:addressId', async () => {
+  test('[DELETE] /recipients/:recipientId/addresses/:addressId', async () => {
     const account = await accountFactory.makePrismaAccount({
       email: 'johndoe@example.com',
       role: 'ADMIN',
@@ -64,10 +64,12 @@ describe('Delete Recipient Address (E2E)', () => {
     })
 
     const response = await request(app.getHttpServer())
-      .delete(`/recipients/addresses/${address.id.toString()}`)
+      .delete(
+        `/recipients/${recipient.id.toString()}/addresses/${address.id.toString()}`,
+      )
       .set('Authorization', `Bearer ${accessToken}`)
 
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(204)
 
     const recipientOnDatabase = await prisma.recipientAddress.findUnique({
       where: {

--- a/src/infra/http/controllers/delivery/recipient/delete-recipient-address.controller.ts
+++ b/src/infra/http/controllers/delivery/recipient/delete-recipient-address.controller.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Controller,
   Delete,
+  HttpCode,
   NotFoundException,
   Param,
 } from '@nestjs/common'
@@ -15,10 +16,15 @@ export class DeleteRecipientAddressController {
     private deleteRecipientAddressUseCase: DeleteRecipientAddressUseCase,
   ) {}
 
-  @Delete('/recipients/addresses/:addressId')
+  @Delete('/recipients/:recipientId/addresses/:addressId')
   @Roles('ADMIN')
-  async handle(@Param('addressId') addressId: string) {
+  @HttpCode(204)
+  async handle(
+    @Param('recipientId') recipientId: string,
+    @Param('addressId') addressId: string,
+  ) {
     const result = await this.deleteRecipientAddressUseCase.execute({
+      recipientId,
       recipientAddressId: addressId,
     })
 

--- a/src/infra/http/controllers/delivery/recipient/update-recipient-address.controller.e2e-spec.ts
+++ b/src/infra/http/controllers/delivery/recipient/update-recipient-address.controller.e2e-spec.ts
@@ -1,4 +1,5 @@
 import { AppModule } from '@/app.module'
+import { GeocodingService } from '@/domain/delivery/application/location/geocoding-service'
 import { DatabaseModule } from '@/infra/database/database.module'
 import { PrismaService } from '@/infra/database/prisma/prisma.service'
 import { JwtService } from '@nestjs/jwt'
@@ -11,6 +12,7 @@ import request from 'supertest'
 import { RecipientFactory } from 'test/factories/delivery/make-recipient'
 import { RecipientAddressFactory } from 'test/factories/delivery/make-recipient-address'
 import { AccountFactory } from 'test/factories/identity/make-account'
+import { FakeGeocodingService } from 'test/location/fake-geocoding-service'
 import { PrismaServiceE2E } from 'test/prisma-service-e2e'
 
 describe('Update Recipient Address (E2E)', () => {
@@ -28,6 +30,8 @@ describe('Update Recipient Address (E2E)', () => {
     })
       .overrideProvider(PrismaService)
       .useClass(PrismaServiceE2E)
+      .overrideProvider(GeocodingService)
+      .useClass(FakeGeocodingService)
       .compile()
 
     app = moduleRef.createNestApplication<NestFastifyApplication>(
@@ -46,7 +50,7 @@ describe('Update Recipient Address (E2E)', () => {
     await app.getHttpAdapter().getInstance().ready()
   })
 
-  test('[PUT] /recipients/addresses/:addressId', async () => {
+  test('[PUT] /recipients/:recipientId/addresses/:addressId', async () => {
     const account = await accountFactory.makePrismaAccount({
       email: 'johndoe@example.com',
       role: 'ADMIN',
@@ -72,7 +76,9 @@ describe('Update Recipient Address (E2E)', () => {
     })
 
     const response = await request(app.getHttpServer())
-      .put(`/recipients/addresses/${address.id.toString()}`)
+      .put(
+        `/recipients/${recipient.id.toString()}/addresses/${address.id.toString()}`,
+      )
       .set('Authorization', `Bearer ${accessToken}`)
       .send({
         street: 'New Street',
@@ -85,7 +91,7 @@ describe('Update Recipient Address (E2E)', () => {
         postalCode: '87654-321',
       })
 
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(204)
 
     const recipientOnDatabase = await prisma.recipientAddress.findUnique({
       where: {

--- a/src/infra/http/controllers/delivery/recipient/update-recipient-address.controller.ts
+++ b/src/infra/http/controllers/delivery/recipient/update-recipient-address.controller.ts
@@ -1,7 +1,9 @@
 import {
-  BadRequestException,
+  BadGatewayException,
   Body,
   Controller,
+  HttpCode,
+  InternalServerErrorException,
   NotFoundException,
   Param,
   Put,
@@ -11,6 +13,10 @@ import { ZodValidationPipe } from '../../../pipes/zod-validation-pipe'
 import { Roles } from '@/infra/auth/roles.decorator'
 import { UpdateRecipientAddressUseCase } from '@/domain/delivery/application/use-cases/recipient/update-recipient-address'
 import { RecipientAddressNotFoundError } from '@/domain/delivery/application/use-cases/recipient/errors/recipient-address-not-found-error'
+import {
+  GeocodingConfigurationError,
+  GeocodingInvalidResponseError,
+} from '@/domain/delivery/application/use-cases/errors/geocoding-service-error'
 
 const updateRecipientAddressBodySchema = z.object({
   street: z.string(),
@@ -33,12 +39,14 @@ export class UpdateRecipientAddressController {
     private updateRecipientAddressUseCase: UpdateRecipientAddressUseCase,
   ) {}
 
-  @Put('/recipients/addresses/:addressId')
+  @Put('/recipients/:recipientId/addresses/:addressId')
   @Roles('ADMIN')
+  @HttpCode(204)
   async handle(
+    @Param('recipientId') recipientId: string,
+    @Param('addressId') addressId: string,
     @Body(new ZodValidationPipe(updateRecipientAddressBodySchema))
     body: UpdateRecipientAddressBodySchema,
-    @Param('addressId') addressId: string,
   ) {
     const {
       street,
@@ -52,6 +60,7 @@ export class UpdateRecipientAddressController {
     } = body
 
     const result = await this.updateRecipientAddressUseCase.execute({
+      recipientId,
       recipientAddressId: addressId,
       street,
       number,
@@ -66,12 +75,19 @@ export class UpdateRecipientAddressController {
     if (result.isLeft()) {
       const error = result.value
 
-      switch (error.constructor) {
-        case RecipientAddressNotFoundError:
-          throw new NotFoundException(error.message)
-        default:
-          throw new BadRequestException(error.message)
+      if (error instanceof RecipientAddressNotFoundError) {
+        throw new NotFoundException(error.message)
       }
+
+      if (error instanceof GeocodingConfigurationError) {
+        throw new InternalServerErrorException(error.message)
+      }
+
+      if (error instanceof GeocodingInvalidResponseError) {
+        throw new BadGatewayException(error.message)
+      }
+
+      throw new InternalServerErrorException(error.message)
     }
   }
 }


### PR DESCRIPTION
## Description

Refactored recipient address endpoints to use nested routes (`/recipients/:recipientId/addresses/:addressId`), aligning PUT and DELETE with the existing POST and GET pattern. Added ownership validation to prevent cross-recipient mutations, geocoordinate recomputation on address update, and replaced switch (`error.constructor`) with `instanceof` checks to correctly handle geocoding error subclasses with semantically accurate HTTP status codes.

## Type of Change

- [ ] Feature (new functionality)
- [x] Bugfix (fixes an issue)
- [ ] Hotfix (critical fix for production)
- [x] Refactor (code improvement without changing functionality)
- [ ] Documentation
- [ ] Chore (maintenance, dependencies, configs)

## Branch

- **Source:** `refactor/nested-recipient-address-routes`
- **Target:** `develop`

## Checklist

- [x] Code follows project standards
- [x] Tests added/updated (if applicable)
- [ ] Documentation updated (if applicable)
- [x] Self-reviewed the code
