### PR TITLE
feat(api): Add OpenAPI documentation with Scalar API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,20 @@ Fast Feet API manages the full lifecycle of package deliveries — from account 
 
 ## Tech Stack
 
-| Category         | Technology                                                                                        |
-| ---------------- | ------------------------------------------------------------------------------------------------- |
-| Runtime          | [Node.js](https://nodejs.org/)                                                                    |
-| Framework        | [NestJS](https://nestjs.com/) + [Fastify](https://fastify.dev/)                                   |
-| Language         | [TypeScript](https://www.typescriptlang.org/)                                                     |
-| Database         | [PostgreSQL](https://www.postgresql.org/) via [Prisma ORM](https://www.prisma.io/)                |
-| Auth             | [JWT](https://jwt.io/) (RS256) + [Passport.js](https://www.passportjs.org/)                       |
-| Password Hashing | [Argon2](https://github.com/ranisalt/node-argon2)                                                 |
-| Validation       | [Zod](https://zod.dev/) + [zod-validation-error](https://github.com/causaly/zod-validation-error) |
-| Geocoding        | [Nominatim / OpenStreetMap](https://nominatim.org/) via `@nestjs/axios`                           |
-| Testing          | [Vitest](https://vitest.dev/) + [Supertest](https://github.com/ladjs/supertest)                   |
-| Containerization | [Docker](https://www.docker.com/) + Docker Compose                                                |
-| CI               | GitHub Actions                                                                                    |
+| Category         | Technology                                                                                                                       |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Runtime          | [Node.js](https://nodejs.org/)                                                                                                   |
+| Framework        | [NestJS](https://nestjs.com/) + [Fastify](https://fastify.dev/)                                                                  |
+| Language         | [TypeScript](https://www.typescriptlang.org/)                                                                                    |
+| Database         | [PostgreSQL](https://www.postgresql.org/) via [Prisma ORM](https://www.prisma.io/)                                               |
+| Auth             | [JWT](https://jwt.io/) (RS256) + [Passport.js](https://www.passportjs.org/)                                                      |
+| Password Hashing | [Argon2](https://github.com/ranisalt/node-argon2)                                                                                |
+| Validation       | [Zod](https://zod.dev/) + [zod-validation-error](https://github.com/causaly/zod-validation-error)                                |
+| API Docs         | [OpenAPI](https://www.openapis.org/) via [Swagger](https://docs.nestjs.com/openapi/introduction) + [Scalar](https://scalar.com/) |
+| Geocoding        | [Nominatim / OpenStreetMap](https://nominatim.org/) via `@nestjs/axios`                                                          |
+| Testing          | [Vitest](https://vitest.dev/) + [Supertest](https://github.com/ladjs/supertest)                                                  |
+| Containerization | [Docker](https://www.docker.com/) + Docker Compose                                                                               |
+| CI               | GitHub Actions                                                                                                                   |
 
 ---
 
@@ -54,6 +55,7 @@ Fast Feet API manages the full lifecycle of package deliveries — from account 
 - **Proof of delivery** — couriers complete deliveries by submitting receiver evidence, optional GPS coordinates, and a proof image URL reference
 - **Nearby deliveries** — couriers query their own pending deliveries within a configurable radius (km) using the **Haversine formula** and paginated results
 - **Role-based access control** — global `JwtAuthGuard` + `RolesGuard`; admins manage the platform, couriers act only on their own deliveries
+- **Interactive API documentation** — OpenAPI schema generated from NestJS Swagger decorators and rendered with Scalar
 - **CI pipelines** — unit tests and E2E tests run automatically on every pull request via GitHub Actions
 
 ---
@@ -112,6 +114,18 @@ The geocoding service is abstracted behind a `GeocodingService` interface in the
 ### Zod for runtime validation at the HTTP boundary
 
 Zod schemas are defined in each controller and piped through a custom `ZodValidationPipe`. This keeps validation co-located with the route handler, provides descriptive error messages via `zod-validation-error`, and avoids the overhead of class-transformer/class-validator decorators throughout the codebase.
+
+### OpenAPI documentation with Scalar
+
+The API exposes a generated OpenAPI specification using `@nestjs/swagger`, with Scalar providing the interactive reference UI. The generated contract documents authentication, role requirements, request bodies, query parameters, path parameters, response models, and common error responses.
+
+The implementation intentionally separates runtime validation from documentation:
+
+- **Zod schemas** validate real incoming HTTP data at runtime.
+- **Swagger DTOs and response classes** describe the public API contract for OpenAPI generation.
+- **Scalar** consumes the generated JSON spec and provides a clean interface for exploring and testing endpoints.
+
+**Trade-off:** Zod and Swagger DTOs duplicate some request shape definitions. This is acceptable here because Zod remains the source of runtime validation, while explicit Swagger classes keep the public contract readable and presentation-focused. In a larger production codebase, this could be reduced with a schema-to-OpenAPI generation strategy.
 
 ### Isolated E2E test schemas
 
@@ -252,6 +266,20 @@ At least one evidence field must be present: `receivedByDocument` or `proofImage
 
 ---
 
+## API Documentation
+
+After starting the development server, the API documentation is available at:
+
+| Resource             | URL                               |
+| -------------------- | --------------------------------- |
+| Scalar API reference | `http://localhost:3333/reference` |
+| OpenAPI JSON schema  | `http://localhost:3333/docs/json` |
+| OpenAPI YAML schema  | `http://localhost:3333/docs/yaml` |
+
+The documentation includes grouped endpoints for identity, couriers, recipients, and deliveries, plus Bearer JWT authentication support. Authenticate with `POST /sessions`, then use the returned access token in the Scalar reference as `Bearer <token>`.
+
+---
+
 ## Getting Started
 
 **Requirements:** Node.js 22+, pnpm, Docker and Docker Compose.
@@ -333,6 +361,7 @@ pnpm test:cov
 - [x] Transition delivery status: CREATED → ASSIGNED → IN_TRANSIT → COMPLETED
 - [x] Complete deliveries with proof of delivery evidence
 - [x] Couriers query their nearby deliveries by coordinates and radius
+- [x] Explore the API through generated OpenAPI documentation and Scalar reference UI
 
 ### Business Rules
 
@@ -355,6 +384,7 @@ pnpm test:cov
 - [x] Unit and E2E tests with Vitest + isolated test schemas
 - [x] CI pipelines (unit + E2E) on every pull request via GitHub Actions
 - [x] Input validation at the HTTP boundary using Zod schemas
+- [x] OpenAPI contract generated from annotated controllers, DTOs, and response models
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:e2e": "vitest run --config ./vitest.config.e2e.ts"
   },
   "dependencies": {
+    "@fastify/static": "^9.1.3",
     "@nestjs/axios": "^4.0.1",
     "@nestjs/common": "^11.1.19",
     "@nestjs/config": "^4.0.4",
@@ -27,8 +28,10 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-fastify": "^11.1.19",
+    "@nestjs/swagger": "^11.4.3",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
+    "@scalar/nestjs-api-reference": "^1.1.16",
     "argon2": "^0.44.0",
     "axios": "^1.15.2",
     "passport-jwt": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@fastify/static':
+        specifier: ^9.1.3
+        version: 9.1.3
       '@nestjs/axios':
         specifier: ^4.0.1
         version: 4.0.1(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.15.2)(rxjs@7.8.2)
@@ -19,7 +22,7 @@ importers:
         version: 4.0.4(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)
       '@nestjs/core':
         specifier: ^11.1.19
-        version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.12)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/jwt':
         specifier: ^11.0.2
         version: 11.0.2(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))
@@ -28,13 +31,19 @@ importers:
         version: 11.0.5(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(passport@0.7.0)
       '@nestjs/platform-fastify':
         specifier: ^11.1.19
-        version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
+        version: 11.1.19(@fastify/static@9.1.3)(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))
+      '@nestjs/swagger':
+        specifier: ^11.4.3
+        version: 11.4.3(@fastify/static@9.1.3)(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)
       '@prisma/adapter-pg':
         specifier: ^7.8.0
         version: 7.8.0
       '@prisma/client':
         specifier: ^7.8.0
         version: 7.8.0(prisma@7.8.0(@types/react@19.2.9)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
+      '@scalar/nestjs-api-reference':
+        specifier: ^1.1.16
+        version: 1.1.16
       argon2:
         specifier: ^0.44.0
         version: 0.44.0
@@ -74,7 +83,7 @@ importers:
         version: 11.1.0(chokidar@4.0.3)(prettier@3.8.3)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.19
-        version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(@nestjs/platform-express@11.1.12)
+        version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))
       '@swc/cli':
         specifier: ^0.8.1
         version: 0.8.1(@swc/core@1.15.32)(chokidar@4.0.3)
@@ -415,6 +424,9 @@ packages:
     resolution: {integrity: sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==}
     engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
 
+  '@fastify/accept-negotiator@2.0.1':
+    resolution: {integrity: sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==}
+
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
 
@@ -438,6 +450,12 @@ packages:
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
+  '@fastify/send@4.1.0':
+    resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
+
+  '@fastify/static@9.1.3':
+    resolution: {integrity: sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==}
 
   '@hono/node-server@1.19.11':
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
@@ -640,6 +658,13 @@ packages:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
 
+  '@lukeed/ms@2.0.2':
+    resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
+    engines: {node: '>=8'}
+
+  '@microsoft/tsdoc@0.16.0':
+    resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
+
   '@napi-rs/nice-android-arm-eabi@1.1.1':
     resolution: {integrity: sha512-kjirL3N6TnRPv5iuHw36wnucNqXAO46dzK9oPb0wj076R5Xm8PfUVA9nAFB5ZNMmfJQJVKACAPd/Z2KYMppthw==}
     engines: {node: '>= 10'}
@@ -815,17 +840,24 @@ packages:
     peerDependencies:
       '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
 
+  '@nestjs/mapped-types@2.1.1':
+    resolution: {integrity: sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      class-transformer: ^0.4.0 || ^0.5.0
+      class-validator: ^0.13.0 || ^0.14.0 || ^0.15.0
+      reflect-metadata: ^0.1.12 || ^0.2.0
+    peerDependenciesMeta:
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+
   '@nestjs/passport@11.0.5':
     resolution: {integrity: sha512-ulQX6mbjlws92PIM15Naes4F4p2JoxGnIJuUsdXQPT+Oo2sqQmENEZXM7eYuimocfHnKlcfZOuyzbA33LwUlOQ==}
     peerDependencies:
       '@nestjs/common': ^10.0.0 || ^11.0.0
       passport: ^0.5.0 || ^0.6.0 || ^0.7.0
-
-  '@nestjs/platform-express@11.1.12':
-    resolution: {integrity: sha512-GYK/vHI0SGz5m8mxr7v3Urx8b9t78Cf/dj5aJMZlGd9/1D9OI1hAl00BaphjEXINUJ/BQLxIlF2zUjrYsd6enQ==}
-    peerDependencies:
-      '@nestjs/common': ^11.0.0
-      '@nestjs/core': ^11.0.0
 
   '@nestjs/platform-fastify@11.1.19':
     resolution: {integrity: sha512-PdldJPw+xu8JM7VNE2FY+ty+qoxDMW7326h/z0MtfZvKj84FE6zuqpcSXen1CYjtyP8og+x/5XrJbKKKDNabtQ==}
@@ -847,6 +879,23 @@ packages:
       typescript: '>=4.8.2'
     peerDependenciesMeta:
       prettier:
+        optional: true
+
+  '@nestjs/swagger@11.4.3':
+    resolution: {integrity: sha512-LR4BuOj+iBFzhGRnNP0OHjmrPXliDEjrmniXtLsfLDIELjkuUXYCTGjZMqgDdOY+QSabeF59LndaDzOOe+vMmw==}
+    peerDependencies:
+      '@fastify/static': ^8.0.0 || ^9.0.0
+      '@nestjs/common': ^11.0.1
+      '@nestjs/core': ^11.0.1
+      class-transformer: '*'
+      class-validator: '*'
+      reflect-metadata: ^0.1.12 || ^0.2.0
+    peerDependenciesMeta:
+      '@fastify/static':
+        optional: true
+      class-transformer:
+        optional: true
+      class-validator:
         optional: true
 
   '@nestjs/testing@11.1.19':
@@ -1168,6 +1217,33 @@ packages:
     resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
     cpu: [x64]
     os: [win32]
+
+  '@scalar/client-side-rendering@0.1.9':
+    resolution: {integrity: sha512-Gv3CK0X+BqXYkVJLTQXNM8YgdquhuGV4hKlsM8S9k5GGonj8LBDSAiuU3W48JGX1pY7hRotBGcIIU+1a1X1mcw==}
+    engines: {node: '>=22'}
+
+  '@scalar/helpers@0.8.0':
+    resolution: {integrity: sha512-gmOC6VravNB9VDl6wnt/GOj4K/hn48tj5bpW4AM4MhH8Ubil6uu7g1DSoKHwltu8Ks79KEtR6JmOrROi9R7jaQ==}
+    engines: {node: '>=22'}
+
+  '@scalar/nestjs-api-reference@1.1.16':
+    resolution: {integrity: sha512-L1c5eZfFuiWu2ldfcF81xULEcEMk8OpRH61rAq9VkWDZFF4pcMXIuQcsPPHhSpmOzl66kmhUWj84Yt4xE6XwRA==}
+    engines: {node: '>=22'}
+
+  '@scalar/schemas@0.2.0':
+    resolution: {integrity: sha512-FOpNecNoEKo8SogHEsdWlVRN4Q4PH3dzuOBWMA5tGt1xLZu5iFnPG2X/h6+Z/mOR34c7iW+hiKTqdUZoDgT9CA==}
+    engines: {node: '>=22'}
+
+  '@scalar/types@0.11.0':
+    resolution: {integrity: sha512-TGZR8sys1jRlaWxLYfBo8y6D1W4UClYuDmkJ6Hmsb7oNuqokEAAK+AVYIzascVdBmaly0D1fqoqK7CzuGYHgyg==}
+    engines: {node: '>=22'}
+
+  '@scalar/validation@0.5.0':
+    resolution: {integrity: sha512-48CS1B0C7im57RQCHhS0GKt+qDLxB34IX8rO91jZj9D+Y/OosQZG3Gy57gJdHqZoD7l0sPUZtF8tVYry3BxRtw==}
+    engines: {node: '>=20'}
+
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -1584,10 +1660,6 @@ packages:
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
-  accepts@2.0.0:
-    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
-    engines: {node: '>= 0.6'}
-
   acorn-import-phases@1.0.4:
     resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
     engines: {node: '>=10.13.0'}
@@ -1658,9 +1730,6 @@ packages:
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
-
-  append-field@1.0.0:
-    resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
 
   arch@3.0.0:
     resolution: {integrity: sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==}
@@ -1750,10 +1819,6 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
-    engines: {node: '>=18'}
-
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
@@ -1781,17 +1846,9 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
-  busboy@1.6.0:
-    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
-    engines: {node: '>=10.16.0'}
-
   byte-counter@0.1.0:
     resolution: {integrity: sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==}
     engines: {node: '>=20'}
-
-  bytes@3.1.2:
-    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
-    engines: {node: '>= 0.8'}
 
   c12@3.3.4:
     resolution: {integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==}
@@ -1907,10 +1964,6 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  concat-stream@2.0.0:
-    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
-    engines: {'0': node >= 6.0}
-
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
@@ -1921,10 +1974,6 @@ packages:
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
     engines: {node: '>=18'}
-
-  content-type@1.0.5:
-    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
-    engines: {node: '>= 0.6'}
 
   convert-hrtime@5.0.0:
     resolution: {integrity: sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==}
@@ -1937,20 +1986,12 @@ packages:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
 
-  cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
-    engines: {node: '>= 0.6'}
-
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
-
-  cors@2.8.5:
-    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
-    engines: {node: '>= 0.10'}
 
   cosmiconfig@8.3.6:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
@@ -2055,9 +2096,6 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
-  ee-first@1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
-
   effect@3.20.0:
     resolution: {integrity: sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw==}
 
@@ -2070,10 +2108,6 @@ packages:
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
-
-  encodeurl@2.0.0:
-    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
-    engines: {node: '>= 0.8'}
 
   enhanced-resolve@5.21.0:
     resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
@@ -2210,10 +2244,6 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  etag@1.8.1:
-    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
-    engines: {node: '>= 0.6'}
-
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
@@ -2232,10 +2262,6 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
-
-  express@5.2.1:
-    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
-    engines: {node: '>= 18'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -2320,10 +2346,6 @@ packages:
     resolution: {integrity: sha512-9b4rfnaX2MkJCgp27wypV6DAMvj4WMOSgJ+TdcpJIO84Dql+Cv6iJjdG4XDTLubOWkfNiBv3joO59sau/TXw+Q==}
     engines: {node: '>=20'}
 
-  finalhandler@2.1.1:
-    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
-    engines: {node: '>= 18.0.0'}
-
   find-my-way@9.5.0:
     resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
     engines: {node: '>=20'}
@@ -2374,14 +2396,6 @@ packages:
   formidable@3.5.4:
     resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
     engines: {node: '>=14.0.0'}
-
-  forwarded@0.2.0:
-    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
-    engines: {node: '>= 0.6'}
-
-  fresh@2.0.0:
-    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
-    engines: {node: '>= 0.8'}
 
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -2538,10 +2552,6 @@ packages:
   inspect-with-kind@1.0.5:
     resolution: {integrity: sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==}
 
-  ipaddr.js@1.9.1:
-    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
-    engines: {node: '>= 0.10'}
-
   ipaddr.js@2.3.0:
     resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
     engines: {node: '>= 10'}
@@ -2572,9 +2582,6 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
-
-  is-promise@4.0.0:
-    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-property@1.0.2:
     resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
@@ -2778,21 +2785,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  media-typer@0.3.0:
-    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
-    engines: {node: '>= 0.6'}
-
-  media-typer@1.1.0:
-    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
-    engines: {node: '>= 0.8'}
-
   memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
-
-  merge-descriptors@2.0.0:
-    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
-    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -2813,13 +2808,14 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
-  mime-types@3.0.2:
-    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
-    engines: {node: '>=18'}
-
   mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
     engines: {node: '>=4.0.0'}
+    hasBin: true
+
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
     hasBin: true
 
   mimic-fn@2.1.0:
@@ -2852,16 +2848,8 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  mkdirp@0.5.6:
-    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
-    hasBin: true
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  multer@2.0.2:
-    resolution: {integrity: sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==}
-    engines: {node: '>= 10.16.0'}
 
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
@@ -2880,12 +2868,13 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@5.1.11:
+    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
-
-  negotiator@1.0.0:
-    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
-    engines: {node: '>= 0.6'}
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
@@ -2919,10 +2908,6 @@ packages:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
 
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -2936,10 +2921,6 @@ packages:
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
-
-  on-finished@2.4.1:
-    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
-    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -2992,10 +2973,6 @@ packages:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
 
-  parseurl@1.3.3:
-    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
-    engines: {node: '>= 0.8'}
-
   passport-jwt@4.0.1:
     resolution: {integrity: sha512-UCKMDYhNuGOBE9/9Ycuoyh7vP6jpeTp/+sfMJl7nLff/t6dps+iaeE0hhNkKN8/HZHcJ7lCdOyDxHdDoxoSvdQ==}
 
@@ -3022,9 +2999,6 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
-
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
@@ -3173,10 +3147,6 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
-  proxy-addr@2.0.7:
-    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
-    engines: {node: '>= 0.10'}
-
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
@@ -3198,14 +3168,6 @@ packages:
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
-
-  range-parser@1.2.1:
-    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
-    engines: {node: '>= 0.6'}
-
-  raw-body@3.0.2:
-    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
-    engines: {node: '>= 0.10'}
 
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
@@ -3280,10 +3242,6 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  router@2.2.0:
-    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
-    engines: {node: '>= 18'}
-
   rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
 
@@ -3335,16 +3293,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  send@1.2.1:
-    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
-    engines: {node: '>= 18'}
-
   seq-queue@0.0.5:
     resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
-
-  serve-static@2.2.1:
-    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
-    engines: {node: '>= 18'}
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
@@ -3441,10 +3391,6 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
-  streamsearch@1.1.0:
-    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
-    engines: {node: '>=10.0.0'}
-
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
@@ -3502,6 +3448,9 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  swagger-ui-dist@5.32.6:
+    resolution: {integrity: sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==}
+
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
     engines: {node: '>=0.10'}
@@ -3509,6 +3458,10 @@ packages:
   synckit@0.11.12:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
@@ -3618,16 +3571,9 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
-  type-is@1.6.18:
-    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
-    engines: {node: '>= 0.6'}
-
-  type-is@2.0.1:
-    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
-    engines: {node: '>= 0.6'}
-
-  typedarray@0.0.6:
-    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
 
   typescript-eslint@8.59.1:
     resolution: {integrity: sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==}
@@ -3662,10 +3608,6 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
-
-  unpipe@1.0.0:
-    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
-    engines: {node: '>= 0.8'}
 
   unplugin-swc@1.5.9:
     resolution: {integrity: sha512-RKwK3yf0M+MN17xZfF14bdKqfx0zMXYdtOdxLiE6jHAoidupKq3jGdJYANyIM1X/VmABhh1WpdO+/f4+Ol89+g==}
@@ -3702,10 +3644,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  vary@1.1.2:
-    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
-    engines: {node: '>= 0.8'}
 
   vite@7.3.0:
     resolution: {integrity: sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==}
@@ -4085,6 +4023,8 @@ snapshots:
 
   '@faker-js/faker@10.4.0': {}
 
+  '@fastify/accept-negotiator@2.0.1': {}
+
   '@fastify/ajv-compiler@4.0.5':
     dependencies:
       ajv: 8.20.0
@@ -4117,6 +4057,23 @@ snapshots:
     dependencies:
       '@fastify/forwarded': 3.0.1
       ipaddr.js: 2.3.0
+
+  '@fastify/send@4.1.0':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      escape-html: 1.0.3
+      fast-decode-uri-component: 1.0.1
+      http-errors: 2.0.1
+      mime: 3.0.0
+
+  '@fastify/static@9.1.3':
+    dependencies:
+      '@fastify/accept-negotiator': 2.0.1
+      '@fastify/send': 4.1.0
+      content-disposition: 1.1.0
+      fastify-plugin: 5.1.0
+      fastq: 1.20.1
+      glob: 13.0.6
 
   '@hono/node-server@1.19.11(hono@4.12.15)':
     dependencies:
@@ -4313,6 +4270,10 @@ snapshots:
 
   '@lukeed/csprng@1.1.0': {}
 
+  '@lukeed/ms@2.0.2': {}
+
+  '@microsoft/tsdoc@0.16.0': {}
+
   '@napi-rs/nice-android-arm-eabi@1.1.1':
     optional: true
 
@@ -4441,7 +4402,7 @@ snapshots:
       lodash: 4.18.1
       rxjs: 7.8.2
 
-  '@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.12)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+  '@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nuxt/opencollective': 0.4.1
@@ -4452,8 +4413,6 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
       uid: 2.0.2
-    optionalDependencies:
-      '@nestjs/platform-express': 11.1.12(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
 
   '@nestjs/jwt@11.0.2(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))':
     dependencies:
@@ -4461,30 +4420,22 @@ snapshots:
       '@types/jsonwebtoken': 9.0.10
       jsonwebtoken: 9.0.3
 
+  '@nestjs/mapped-types@2.1.1(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)':
+    dependencies:
+      '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      reflect-metadata: 0.2.2
+
   '@nestjs/passport@11.0.5(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(passport@0.7.0)':
     dependencies:
       '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
       passport: 0.7.0
 
-  '@nestjs/platform-express@11.1.12(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)':
-    dependencies:
-      '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.12)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      cors: 2.8.5
-      express: 5.2.1
-      multer: 2.0.2
-      path-to-regexp: 8.3.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@nestjs/platform-fastify@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)':
+  '@nestjs/platform-fastify@11.1.19(@fastify/static@9.1.3)(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))':
     dependencies:
       '@fastify/cors': 11.2.0
       '@fastify/formbody': 8.0.2
       '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.12)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       fast-querystring: 1.1.2
       fastify: 5.8.4
       fastify-plugin: 5.1.0
@@ -4493,6 +4444,8 @@ snapshots:
       path-to-regexp: 8.4.2
       reusify: 1.1.0
       tslib: 2.8.1
+    optionalDependencies:
+      '@fastify/static': 9.1.3
 
   '@nestjs/schematics@11.1.0(chokidar@4.0.3)(prettier@3.8.3)(typescript@5.9.3)':
     dependencies:
@@ -4507,13 +4460,25 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/testing@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(@nestjs/platform-express@11.1.12)':
+  '@nestjs/swagger@11.4.3(@fastify/static@9.1.3)(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)':
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/mapped-types': 2.1.1(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)
+      js-yaml: 4.1.1
+      lodash: 4.18.1
+      path-to-regexp: 8.4.2
+      reflect-metadata: 0.2.2
+      swagger-ui-dist: 5.32.6
+    optionalDependencies:
+      '@fastify/static': 9.1.3
+
+  '@nestjs/testing@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))':
     dependencies:
       '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.12)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       tslib: 2.8.1
-    optionalDependencies:
-      '@nestjs/platform-express': 11.1.12(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
 
   '@noble/hashes@1.8.0': {}
 
@@ -4766,6 +4731,33 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
+
+  '@scalar/client-side-rendering@0.1.9':
+    dependencies:
+      '@scalar/schemas': 0.2.0
+      '@scalar/types': 0.11.0
+      '@scalar/validation': 0.5.0
+
+  '@scalar/helpers@0.8.0': {}
+
+  '@scalar/nestjs-api-reference@1.1.16':
+    dependencies:
+      '@scalar/client-side-rendering': 0.1.9
+
+  '@scalar/schemas@0.2.0':
+    dependencies:
+      '@scalar/validation': 0.5.0
+
+  '@scalar/types@0.11.0':
+    dependencies:
+      '@scalar/helpers': 0.8.0
+      nanoid: 5.1.11
+      type-fest: 5.6.0
+      zod: 4.3.6
+
+  '@scalar/validation@0.5.0': {}
+
+  '@scarf/scarf@1.4.0': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -5306,12 +5298,6 @@ snapshots:
 
   abstract-logging@2.0.1: {}
 
-  accepts@2.0.0:
-    dependencies:
-      mime-types: 3.0.2
-      negotiator: 1.0.0
-    optional: true
-
   acorn-import-phases@1.0.4(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -5377,9 +5363,6 @@ snapshots:
       color-convert: 2.0.1
 
   ansis@4.2.0: {}
-
-  append-field@1.0.0:
-    optional: true
 
   arch@3.0.0: {}
 
@@ -5456,21 +5439,6 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  body-parser@2.2.2:
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 4.4.3
-      http-errors: 2.0.1
-      iconv-lite: 0.7.2
-      on-finished: 2.4.1
-      qs: 6.15.1
-      raw-body: 3.0.2
-      type-is: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
@@ -5503,15 +5471,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  busboy@1.6.0:
-    dependencies:
-      streamsearch: 1.1.0
-    optional: true
-
   byte-counter@0.1.0: {}
-
-  bytes@3.1.2:
-    optional: true
 
   c12@3.3.4(magicast@0.5.2):
     dependencies:
@@ -5622,22 +5582,11 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  concat-stream@2.0.0:
-    dependencies:
-      buffer-from: 1.1.2
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-      typedarray: 0.0.6
-    optional: true
-
   confbox@0.2.4: {}
 
   consola@3.4.2: {}
 
   content-disposition@1.1.0: {}
-
-  content-type@1.0.5:
-    optional: true
 
   convert-hrtime@5.0.0: {}
 
@@ -5645,18 +5594,9 @@ snapshots:
 
   cookie-signature@1.2.2: {}
 
-  cookie@0.7.2:
-    optional: true
-
   cookie@1.1.1: {}
 
   cookiejar@2.1.4: {}
-
-  cors@2.8.5:
-    dependencies:
-      object-assign: 4.1.1
-      vary: 1.1.2
-    optional: true
 
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
@@ -5706,8 +5646,7 @@ snapshots:
 
   denque@2.1.0: {}
 
-  depd@2.0.0:
-    optional: true
+  depd@2.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -5740,9 +5679,6 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  ee-first@1.1.1:
-    optional: true
-
   effect@3.20.0:
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -5753,9 +5689,6 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   empathic@2.0.0: {}
-
-  encodeurl@2.0.0:
-    optional: true
 
   enhanced-resolve@5.21.0:
     dependencies:
@@ -5816,8 +5749,7 @@ snapshots:
 
   escalade@3.2.0: {}
 
-  escape-html@1.0.3:
-    optional: true
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -5924,9 +5856,6 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  etag@1.8.1:
-    optional: true
-
   events-universal@1.0.1:
     dependencies:
       bare-events: 2.8.2
@@ -5963,40 +5892,6 @@ snapshots:
       yoctocolors: 2.1.2
 
   expect-type@1.3.0: {}
-
-  express@5.2.1:
-    dependencies:
-      accepts: 2.0.0
-      body-parser: 2.2.2
-      content-disposition: 1.1.0
-      content-type: 1.0.5
-      cookie: 0.7.2
-      cookie-signature: 1.2.2
-      debug: 4.4.3
-      depd: 2.0.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 2.1.1
-      fresh: 2.0.0
-      http-errors: 2.0.1
-      merge-descriptors: 2.0.0
-      mime-types: 3.0.2
-      on-finished: 2.4.1
-      once: 1.4.0
-      parseurl: 1.3.3
-      proxy-addr: 2.0.7
-      qs: 6.15.1
-      range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
-      statuses: 2.0.2
-      type-is: 2.0.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   exsolve@1.0.8: {}
 
@@ -6093,18 +5988,6 @@ snapshots:
     dependencies:
       filename-reserved-regex: 4.0.0
 
-  finalhandler@2.1.1:
-    dependencies:
-      debug: 4.4.3
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   find-my-way@9.5.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -6167,12 +6050,6 @@ snapshots:
       '@paralleldrive/cuid2': 2.3.1
       dezalgo: 1.0.4
       once: 1.4.0
-
-  forwarded@0.2.0:
-    optional: true
-
-  fresh@2.0.0:
-    optional: true
 
   fs-extra@10.1.0:
     dependencies:
@@ -6286,7 +6163,6 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
-    optional: true
 
   http-status-codes@2.3.0: {}
 
@@ -6322,9 +6198,6 @@ snapshots:
     dependencies:
       kind-of: 6.0.3
 
-  ipaddr.js@1.9.1:
-    optional: true
-
   ipaddr.js@2.3.0: {}
 
   is-arrayish@0.2.1: {}
@@ -6342,9 +6215,6 @@ snapshots:
   is-plain-obj@1.1.0: {}
 
   is-plain-obj@4.1.0: {}
-
-  is-promise@4.0.0:
-    optional: true
 
   is-property@1.0.2: {}
 
@@ -6529,18 +6399,9 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  media-typer@0.3.0:
-    optional: true
-
-  media-typer@1.1.0:
-    optional: true
-
   memfs@3.5.3:
     dependencies:
       fs-monkey: 1.1.0
-
-  merge-descriptors@2.0.0:
-    optional: true
 
   merge-stream@2.0.0: {}
 
@@ -6554,12 +6415,9 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
-  mime-types@3.0.2:
-    dependencies:
-      mime-db: 1.54.0
-    optional: true
-
   mime@2.6.0: {}
+
+  mime@3.0.0: {}
 
   mimic-fn@2.1.0: {}
 
@@ -6583,23 +6441,7 @@ snapshots:
 
   minipass@7.1.3: {}
 
-  mkdirp@0.5.6:
-    dependencies:
-      minimist: 1.2.8
-    optional: true
-
   ms@2.1.3: {}
-
-  multer@2.0.2:
-    dependencies:
-      append-field: 1.0.0
-      busboy: 1.6.0
-      concat-stream: 2.0.0
-      mkdirp: 0.5.6
-      object-assign: 4.1.1
-      type-is: 1.6.18
-      xtend: 4.0.2
-    optional: true
 
   mute-stream@2.0.0: {}
 
@@ -6621,10 +6463,9 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  natural-compare@1.4.0: {}
+  nanoid@5.1.11: {}
 
-  negotiator@1.0.0:
-    optional: true
+  natural-compare@1.4.0: {}
 
   neo-async@2.6.2: {}
 
@@ -6651,9 +6492,6 @@ snapshots:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
 
-  object-assign@4.1.1:
-    optional: true
-
   object-inspect@1.13.4: {}
 
   obug@2.1.1: {}
@@ -6661,11 +6499,6 @@ snapshots:
   ohash@2.0.11: {}
 
   on-exit-leak-free@2.1.2: {}
-
-  on-finished@2.4.1:
-    dependencies:
-      ee-first: 1.1.1
-    optional: true
 
   once@1.4.0:
     dependencies:
@@ -6729,9 +6562,6 @@ snapshots:
 
   parse-ms@4.0.0: {}
 
-  parseurl@1.3.3:
-    optional: true
-
   passport-jwt@4.0.1:
     dependencies:
       jsonwebtoken: 9.0.3
@@ -6755,9 +6585,6 @@ snapshots:
     dependencies:
       lru-cache: 11.3.5
       minipass: 7.1.3
-
-  path-to-regexp@8.3.0:
-    optional: true
 
   path-to-regexp@8.4.2: {}
 
@@ -6901,12 +6728,6 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
-  proxy-addr@2.0.7:
-    dependencies:
-      forwarded: 0.2.0
-      ipaddr.js: 1.9.1
-    optional: true
-
   proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
@@ -6920,17 +6741,6 @@ snapshots:
   quick-format-unescaped@4.0.4: {}
 
   quick-lru@5.1.1: {}
-
-  range-parser@1.2.1:
-    optional: true
-
-  raw-body@3.0.2:
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.1
-      iconv-lite: 0.7.2
-      unpipe: 1.0.0
-    optional: true
 
   rc9@3.0.1:
     dependencies:
@@ -7014,17 +6824,6 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
-  router@2.2.0:
-    dependencies:
-      debug: 4.4.3
-      depd: 2.0.0
-      is-promise: 4.0.0
-      parseurl: 1.3.3
-      path-to-regexp: 8.3.0
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   rxjs@7.8.1:
     dependencies:
       tslib: 2.8.1
@@ -7072,39 +6871,11 @@ snapshots:
 
   semver@7.7.4: {}
 
-  send@1.2.1:
-    dependencies:
-      debug: 4.4.3
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 2.0.0
-      http-errors: 2.0.1
-      mime-types: 3.0.2
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   seq-queue@0.0.5: {}
-
-  serve-static@2.2.1:
-    dependencies:
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      parseurl: 1.3.3
-      send: 1.2.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   set-cookie-parser@2.7.2: {}
 
-  setprototypeof@1.2.0:
-    optional: true
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -7179,15 +6950,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  statuses@2.0.2:
-    optional: true
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
   std-env@4.1.0: {}
-
-  streamsearch@1.1.0:
-    optional: true
 
   streamx@2.25.0:
     dependencies:
@@ -7265,11 +7032,17 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  swagger-ui-dist@5.32.6:
+    dependencies:
+      '@scarf/scarf': 1.4.0
+
   symbol-observable@4.0.0: {}
 
   synckit@0.11.12:
     dependencies:
       '@pkgr/core': 0.2.9
+
+  tagged-tag@1.0.0: {}
 
   tapable@2.3.3: {}
 
@@ -7328,8 +7101,7 @@ snapshots:
 
   toad-cache@3.7.0: {}
 
-  toidentifier@1.0.1:
-    optional: true
+  toidentifier@1.0.1: {}
 
   token-types@6.1.2:
     dependencies:
@@ -7382,21 +7154,9 @@ snapshots:
 
   type-fest@4.41.0: {}
 
-  type-is@1.6.18:
+  type-fest@5.6.0:
     dependencies:
-      media-typer: 0.3.0
-      mime-types: 2.1.35
-    optional: true
-
-  type-is@2.0.1:
-    dependencies:
-      content-type: 1.0.5
-      media-typer: 1.1.0
-      mime-types: 3.0.2
-    optional: true
-
-  typedarray@0.0.6:
-    optional: true
+      tagged-tag: 1.0.0
 
   typescript-eslint@8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
@@ -7427,9 +7187,6 @@ snapshots:
   unicorn-magic@0.3.0: {}
 
   universalify@2.0.1: {}
-
-  unpipe@1.0.0:
-    optional: true
 
   unplugin-swc@1.5.9(@swc/core@1.15.32)(rollup@4.60.2):
     dependencies:
@@ -7466,9 +7223,6 @@ snapshots:
   valibot@1.2.0(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
-
-  vary@1.1.2:
-    optional: true
 
   vite@7.3.0(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.2):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 allowBuilds:
   '@nestjs/core': true
   '@prisma/engines': true
+  '@scarf/scarf': true
   '@swc/core': true
   argon2: true
   esbuild: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
-onlyBuiltDependencies:
-  - '@nestjs/core'
-  - '@prisma/engines'
-  - '@swc/core'
-  - argon2
-  - esbuild
-  - prisma
+allowBuilds:
+  '@nestjs/core': true
+  '@prisma/engines': true
+  '@swc/core': true
+  argon2: true
+  esbuild: true
+  prisma: true

--- a/src/infra/http/controllers/delivery/courier/complete-delivery.controller.ts
+++ b/src/infra/http/controllers/delivery/courier/complete-delivery.controller.ts
@@ -19,6 +19,20 @@ import { CourierNotFoundError } from '@/domain/delivery/application/use-cases/co
 import { RecipientNotFoundError } from '@/domain/delivery/application/use-cases/recipient/errors/recipient-not-found-error'
 import { RecipientAddressNotFoundError } from '@/domain/delivery/application/use-cases/recipient/errors/recipient-address-not-found-error'
 import { ProofOfDeliveryAlreadyExistsError } from '@/domain/delivery/application/use-cases/delivery/errors/proof-of-delivery-already-exists-error'
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiBody,
+  ApiConflictResponse,
+  ApiForbiddenResponse,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger'
+import { CompleteDeliveryDto } from '../../../swagger/dtos/courier/complete-delivery.dto'
 
 const completeDeliveryBodySchema = z.object({
   receivedByName: z.string().trim().min(1),
@@ -40,6 +54,8 @@ const completeDeliveryBodySchema = z.object({
 
 type CompleteDeliveryBodySchema = z.infer<typeof completeDeliveryBodySchema>
 
+@ApiTags('Couriers')
+@ApiBearerAuth('JWT')
 @Controller()
 export class CompleteDeliveryController {
   constructor(private completeDeliveryUseCase: CompleteDeliveryUseCase) {}
@@ -47,6 +63,41 @@ export class CompleteDeliveryController {
   @Patch('/couriers/me/deliveries/:deliveryId/complete')
   @Roles('WORKER')
   @HttpCode(204)
+  @ApiOperation({
+    summary: 'Complete a delivery with proof',
+    description: `Submit proof of delivery and transition the delivery from \`IN_TRANSIT\` to \`COMPLETED\`. This operation is atomic — the proof record and status update succeed or fail together.
+
+**Evidence requirements:** At least one of \`receivedByDocument\` or \`proofImageUrl\` must be provided.
+
+**Notes field:** Required when \`recipientRelationship\` is anything other than \`RECIPIENT\`.
+
+**GPS coordinates:** Optional. When provided, the system calculates and stores the distance to the destination and classifies location validation as \`WITHIN_RANGE\` or \`OUT_OF_RANGE\`. When omitted, status is recorded as \`UNAVAILABLE\` — delivery is not blocked.
+
+Only the courier assigned to the delivery can complete it. Requires \`WORKER\` role.`,
+  })
+  @ApiParam({
+    name: 'deliveryId',
+    format: 'uuid',
+    description: 'ID of the delivery to complete.',
+  })
+  @ApiBody({ type: CompleteDeliveryDto })
+  @ApiNoContentResponse({
+    description:
+      'Delivery completed. Proof of delivery recorded. Status is now COMPLETED.',
+  })
+  @ApiBadRequestResponse({
+    description:
+      'Delivery is not in IN_TRANSIT status, or evidence fields are missing.',
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
+  @ApiForbiddenResponse({ description: 'Requires WORKER role.' })
+  @ApiNotFoundResponse({
+    description:
+      'Delivery, courier, recipient, or recipient address not found.',
+  })
+  @ApiConflictResponse({
+    description: 'A proof of delivery already exists for this delivery.',
+  })
   async handle(
     @Param('deliveryId') deliveryId: string,
     @Req() req: { user: UserPayload },

--- a/src/infra/http/controllers/delivery/courier/fetch-courier-deliveries.controller.ts
+++ b/src/infra/http/controllers/delivery/courier/fetch-courier-deliveries.controller.ts
@@ -13,6 +13,17 @@ import { ZodValidationPipe } from '@/infra/http/pipes/zod-validation-pipe'
 import { CourierNotFoundError } from '@/domain/delivery/application/use-cases/courier/errors/courier-not-found-error'
 import { CourierDeliveryDetailsPresenter } from '@/infra/http/presenters/courier-delivery-details-presenter'
 import { Roles } from '@/infra/auth/roles.decorator'
+import {
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger'
+import { CourierDeliveriesListResponse } from '../../../swagger/responses/courier-deliveries-list.response'
 
 const fetchCourierDeliveriesQuerySchema = z.object({
   status: z.enum(['CREATED', 'ASSIGNED', 'IN_TRANSIT', 'COMPLETED']).optional(),
@@ -37,6 +48,8 @@ type FetchCourierDeliveriesQuerySchema = z.infer<
   typeof fetchCourierDeliveriesQuerySchema
 >
 
+@ApiTags('Couriers')
+@ApiBearerAuth('JWT')
 @Controller()
 export class FetchCourierDeliveriesController {
   constructor(
@@ -45,6 +58,40 @@ export class FetchCourierDeliveriesController {
 
   @Get('/couriers/me/deliveries')
   @Roles('WORKER')
+  @ApiOperation({
+    summary: 'List my deliveries',
+    description:
+      'Retrieve a paginated list of deliveries assigned to the authenticated courier. Results can be filtered by delivery status. Requires `WORKER` role.',
+  })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    enum: ['CREATED', 'ASSIGNED', 'IN_TRANSIT', 'COMPLETED'],
+    description: 'Filter deliveries by status. Omit to return all statuses.',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Page number (1-based). Defaults to 1.',
+    example: 1,
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Maximum results per page. Defaults to 20, max 100.',
+    example: 20,
+  })
+  @ApiOkResponse({
+    description: 'List of deliveries for the authenticated courier.',
+    type: CourierDeliveriesListResponse,
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
+  @ApiForbiddenResponse({ description: 'Requires WORKER role.' })
+  @ApiNotFoundResponse({
+    description: 'No courier profile linked to the authenticated account.',
+  })
   async handle(
     @Req() req: { user: UserPayload },
     @Query(new ZodValidationPipe(fetchCourierDeliveriesQuerySchema))

--- a/src/infra/http/controllers/delivery/courier/fetch-nearby-courier-deliveries.controller.ts
+++ b/src/infra/http/controllers/delivery/courier/fetch-nearby-courier-deliveries.controller.ts
@@ -13,6 +13,17 @@ import { ZodValidationPipe } from '@/infra/http/pipes/zod-validation-pipe'
 import { CourierNotFoundError } from '@/domain/delivery/application/use-cases/courier/errors/courier-not-found-error'
 import { CourierDeliveryDetailsPresenter } from '@/infra/http/presenters/courier-delivery-details-presenter'
 import { Roles } from '@/infra/auth/roles.decorator'
+import {
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger'
+import { CourierDeliveriesListResponse } from '../../../swagger/responses/courier-deliveries-list.response'
 
 const fetchNearbyCourierDeliveriesQuerySchema = z.object({
   latitude: z.coerce
@@ -54,6 +65,8 @@ type FetchNearbyCourierDeliveriesQuerySchema = z.infer<
   typeof fetchNearbyCourierDeliveriesQuerySchema
 >
 
+@ApiTags('Couriers')
+@ApiBearerAuth('JWT')
 @Controller()
 export class FetchNearbyCourierDeliveriesController {
   constructor(
@@ -62,6 +75,55 @@ export class FetchNearbyCourierDeliveriesController {
 
   @Get('/couriers/me/deliveries/nearby')
   @Roles('WORKER')
+  @ApiOperation({
+    summary: 'List my nearby deliveries',
+    description:
+      "Returns paginated deliveries assigned to the authenticated courier whose recipient addresses fall within the specified radius of the courier's current position. Distance is calculated using the Haversine formula. Requires `WORKER` role.",
+  })
+  @ApiQuery({
+    name: 'latitude',
+    required: true,
+    type: Number,
+    description: "Courier's current latitude. Range: -90 to 90.",
+    example: -23.5505,
+  })
+  @ApiQuery({
+    name: 'longitude',
+    required: true,
+    type: Number,
+    description: "Courier's current longitude. Range: -180 to 180.",
+    example: -46.6333,
+  })
+  @ApiQuery({
+    name: 'radiusInKm',
+    required: true,
+    type: Number,
+    description: 'Search radius in kilometres. Maximum: 100 km.',
+    example: 5,
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Page number (1-based). Defaults to 1.',
+    example: 1,
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Maximum results per page. Defaults to 20, max 100.',
+    example: 20,
+  })
+  @ApiOkResponse({
+    description: 'List of nearby deliveries for the authenticated courier.',
+    type: CourierDeliveriesListResponse,
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
+  @ApiForbiddenResponse({ description: 'Requires WORKER role.' })
+  @ApiNotFoundResponse({
+    description: 'No courier profile linked to the authenticated account.',
+  })
   async handle(
     @Req() req: { user: UserPayload },
     @Query(new ZodValidationPipe(fetchNearbyCourierDeliveriesQuerySchema))

--- a/src/infra/http/controllers/delivery/courier/pickup-delivery.controller.ts
+++ b/src/infra/http/controllers/delivery/courier/pickup-delivery.controller.ts
@@ -13,7 +13,20 @@ import { PickUpDeliveryUseCase } from '@/domain/delivery/application/use-cases/d
 import { CannotPickUpDeliveryError } from '@/domain/delivery/application/use-cases/delivery/errors/cannot-pick-up-error'
 import { UserPayload } from '@/infra/auth/jwt.strategy'
 import { InvalidCourierAssignedError } from '@/domain/delivery/application/use-cases/delivery/errors/invalid-courier-assigned-error'
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger'
 
+@ApiTags('Couriers')
+@ApiBearerAuth('JWT')
 @Controller()
 export class PickUpDeliveryController {
   constructor(private pickUpDeliveryUseCase: PickUpDeliveryUseCase) {}
@@ -21,6 +34,28 @@ export class PickUpDeliveryController {
   @Patch('/couriers/me/deliveries/:deliveryId/pick-up')
   @Roles('WORKER')
   @HttpCode(204)
+  @ApiOperation({
+    summary: 'Pick up a delivery',
+    description:
+      'Mark a delivery as picked up, transitioning its status from `ASSIGNED` to `IN_TRANSIT`. Only the courier that was assigned to the delivery can perform this action. Requires `WORKER` role.',
+  })
+  @ApiParam({
+    name: 'deliveryId',
+    format: 'uuid',
+    description: 'ID of the delivery to pick up.',
+  })
+  @ApiNoContentResponse({
+    description: 'Delivery picked up. Status is now IN_TRANSIT.',
+  })
+  @ApiBadRequestResponse({
+    description:
+      'Delivery is not in ASSIGNED status, or the authenticated courier is not the one assigned to it.',
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
+  @ApiForbiddenResponse({ description: 'Requires WORKER role.' })
+  @ApiNotFoundResponse({
+    description: 'No delivery found with the provided deliveryId.',
+  })
   async handle(
     @Param('deliveryId') deliveryId: string,
     @Req() req: { user: UserPayload },

--- a/src/infra/http/controllers/delivery/courier/register-courier.controller.ts
+++ b/src/infra/http/controllers/delivery/courier/register-courier.controller.ts
@@ -11,6 +11,18 @@ import { ZodValidationPipe } from '../../../pipes/zod-validation-pipe'
 import { RegisterCourierUseCase } from '@/domain/delivery/application/use-cases/courier/register-courier'
 import { AccountNotFoundError } from '@/domain/delivery/application/use-cases/courier/errors/account-not-found-error'
 import { Roles } from '@/infra/auth/roles.decorator'
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiBody,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger'
+import { RegisterCourierDto } from '../../../swagger/dtos/courier/register-courier.dto'
 
 const registerCourierBodySchema = z.object({
   accountId: z.string(),
@@ -19,6 +31,8 @@ const registerCourierBodySchema = z.object({
 
 type RegisterCourierBodySchema = z.infer<typeof registerCourierBodySchema>
 
+@ApiTags('Couriers')
+@ApiBearerAuth('JWT')
 @Controller()
 @UsePipes(new ZodValidationPipe(registerCourierBodySchema))
 export class RegisterCourierController {
@@ -26,6 +40,21 @@ export class RegisterCourierController {
 
   @Post('/couriers')
   @Roles('ADMIN')
+  @ApiOperation({
+    summary: 'Register a courier',
+    description:
+      'Link a WORKER account to a new courier profile. The `accountId` must reference an existing account with the `WORKER` role. Requires `ADMIN` role.',
+  })
+  @ApiBody({ type: RegisterCourierDto })
+  @ApiCreatedResponse({ description: 'Courier registered successfully.' })
+  @ApiBadRequestResponse({
+    description: 'Invalid request body or validation error.',
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
+  @ApiForbiddenResponse({ description: 'Requires ADMIN role.' })
+  @ApiNotFoundResponse({
+    description: 'No account found with the provided accountId.',
+  })
   async handle(@Body() body: RegisterCourierBodySchema) {
     const { accountId, name } = body
 

--- a/src/infra/http/controllers/delivery/delivery/assign-courier.controller.ts
+++ b/src/infra/http/controllers/delivery/delivery/assign-courier.controller.ts
@@ -13,6 +13,19 @@ import { DeliveryNotFoundError } from '@/domain/delivery/application/use-cases/d
 import { CannotAssignCourierError } from '@/domain/delivery/application/use-cases/delivery/errors/cannot-assign-courier-error'
 import { ZodValidationPipe } from '@/infra/http/pipes/zod-validation-pipe'
 import z from 'zod'
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiBody,
+  ApiForbiddenResponse,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger'
+import { AssignCourierDto } from '../../../swagger/dtos/delivery/assign-courier.dto'
 
 const assignCourierBodySchema = z.object({
   courierId: z.string().uuid(),
@@ -20,6 +33,8 @@ const assignCourierBodySchema = z.object({
 
 type AssignCourierBodySchema = z.infer<typeof assignCourierBodySchema>
 
+@ApiTags('Deliveries')
+@ApiBearerAuth('JWT')
 @Controller()
 export class AssignCourierController {
   constructor(private assignCourierUseCase: AssignCourierUseCase) {}
@@ -27,6 +42,28 @@ export class AssignCourierController {
   @Patch('/deliveries/:deliveryId/assign-courier')
   @Roles('ADMIN')
   @HttpCode(204)
+  @ApiOperation({
+    summary: 'Assign a courier to a delivery',
+    description:
+      'Assign a courier to a delivery, transitioning its status from `CREATED` to `ASSIGNED`. The delivery becomes visible to the assigned courier. Can only be applied to deliveries in `CREATED` status. Requires `ADMIN` role.',
+  })
+  @ApiParam({
+    name: 'deliveryId',
+    format: 'uuid',
+    description: 'ID of the delivery to assign a courier to.',
+  })
+  @ApiBody({ type: AssignCourierDto })
+  @ApiNoContentResponse({
+    description: 'Courier assigned. Delivery status is now ASSIGNED.',
+  })
+  @ApiBadRequestResponse({
+    description: 'Delivery is not in CREATED status and cannot be assigned.',
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
+  @ApiForbiddenResponse({ description: 'Requires ADMIN role.' })
+  @ApiNotFoundResponse({
+    description: 'No delivery found with the provided deliveryId.',
+  })
   async handle(
     @Param('deliveryId') deliveryId: string,
     @Body(new ZodValidationPipe(assignCourierBodySchema))

--- a/src/infra/http/controllers/delivery/delivery/create-delivery.controller.ts
+++ b/src/infra/http/controllers/delivery/delivery/create-delivery.controller.ts
@@ -12,6 +12,18 @@ import { Roles } from '@/infra/auth/roles.decorator'
 import { RecipientNotFoundError } from '@/domain/delivery/application/use-cases/recipient/errors/recipient-not-found-error'
 import { CreateDeliveryUseCase } from '@/domain/delivery/application/use-cases/delivery/create-delivery'
 import { RecipientAddressNotFoundError } from '@/domain/delivery/application/use-cases/recipient/errors/recipient-address-not-found-error'
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiBody,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger'
+import { CreateDeliveryDto } from '../../../swagger/dtos/delivery/create-delivery.dto'
 
 const createDeliveryBodySchema = z.object({
   recipientId: z.string().uuid(),
@@ -20,6 +32,8 @@ const createDeliveryBodySchema = z.object({
 
 type CreateDeliveryBodySchema = z.infer<typeof createDeliveryBodySchema>
 
+@ApiTags('Deliveries')
+@ApiBearerAuth('JWT')
 @Controller()
 @UsePipes(new ZodValidationPipe(createDeliveryBodySchema))
 export class CreateDeliveryController {
@@ -27,6 +41,21 @@ export class CreateDeliveryController {
 
   @Post('/deliveries')
   @Roles('ADMIN')
+  @ApiOperation({
+    summary: 'Create a delivery',
+    description:
+      'Create a new delivery in `CREATED` status, linked to a recipient and one of their geocoded addresses. The delivery must be assigned to a courier before it enters the delivery lifecycle. Requires `ADMIN` role.',
+  })
+  @ApiBody({ type: CreateDeliveryDto })
+  @ApiCreatedResponse({ description: 'Delivery created with status CREATED.' })
+  @ApiBadRequestResponse({
+    description: 'Invalid request body or validation error.',
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
+  @ApiForbiddenResponse({ description: 'Requires ADMIN role.' })
+  @ApiNotFoundResponse({
+    description: 'Recipient or recipient address not found.',
+  })
   async handle(@Body() body: CreateDeliveryBodySchema) {
     const { recipientId, recipientAddressId } = body
 

--- a/src/infra/http/controllers/delivery/delivery/delete-delivery.controller.ts
+++ b/src/infra/http/controllers/delivery/delivery/delete-delivery.controller.ts
@@ -9,16 +9,49 @@ import { Roles } from '@/infra/auth/roles.decorator'
 import { DeliveryNotFoundError } from '@/domain/delivery/application/use-cases/delivery/errors/delivery-not-found-error'
 import { DeleteDeliveryUseCase } from '@/domain/delivery/application/use-cases/delivery/delete-delivery'
 import { CannotDeleteDeliveryError } from '@/domain/delivery/application/use-cases/delivery/errors/cannot-delete-delivery-error'
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger'
 
+@ApiTags('Deliveries')
+@ApiBearerAuth('JWT')
 @Controller()
 export class DeleteDeliveryController {
   constructor(private deleteDeliveryUseCase: DeleteDeliveryUseCase) {}
 
-  @Delete('/deliveries/:id')
+  @Delete('/deliveries/:deliveryId')
   @Roles('ADMIN')
-  async handle(@Param('id') id: string) {
+  @ApiOperation({
+    summary: 'Delete a delivery',
+    description:
+      'Permanently delete a delivery. Only deliveries with status `CREATED` (not yet assigned to a courier) can be deleted. Requires `ADMIN` role.',
+  })
+  @ApiParam({
+    name: 'deliveryId',
+    format: 'uuid',
+    description: 'ID of the delivery to delete.',
+  })
+  @ApiOkResponse({ description: 'Delivery deleted successfully.' })
+  @ApiBadRequestResponse({
+    description:
+      'Delivery cannot be deleted because its status is not CREATED.',
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
+  @ApiForbiddenResponse({ description: 'Requires ADMIN role.' })
+  @ApiNotFoundResponse({
+    description: 'No delivery found with the provided id.',
+  })
+  async handle(@Param('deliveryId') deliveryId: string) {
     const result = await this.deleteDeliveryUseCase.execute({
-      deliveryId: id,
+      deliveryId,
     })
 
     if (result.isLeft()) {

--- a/src/infra/http/controllers/delivery/delivery/fetch-deliveries.controller.ts
+++ b/src/infra/http/controllers/delivery/delivery/fetch-deliveries.controller.ts
@@ -4,6 +4,16 @@ import { ZodValidationPipe } from '@/infra/http/pipes/zod-validation-pipe'
 import { FetchDeliveriesUseCase } from '@/domain/delivery/application/use-cases/delivery/fetch-deliveries'
 import { Roles } from '@/infra/auth/roles.decorator'
 import { DeliveryDetailsPresenter } from '@/infra/http/presenters/delivery-details-presenter'
+import {
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger'
+import { DeliveriesListResponse } from '../../../swagger/responses/deliveries-list.response'
 
 const fetchDeliveriesQuerySchema = z.object({
   status: z.enum(['CREATED', 'ASSIGNED', 'IN_TRANSIT', 'COMPLETED']).optional(),
@@ -26,12 +36,46 @@ const fetchDeliveriesQuerySchema = z.object({
 
 type FetchDeliveriesQuerySchema = z.infer<typeof fetchDeliveriesQuerySchema>
 
+@ApiTags('Deliveries')
+@ApiBearerAuth('JWT')
 @Controller()
 export class FetchDeliveriesController {
   constructor(private fetchDeliveriesUseCase: FetchDeliveriesUseCase) {}
 
   @Get('/deliveries')
   @Roles('ADMIN')
+  @ApiOperation({
+    summary: 'List deliveries',
+    description:
+      'Return a paginated list of all deliveries with enriched details — including recipient name and assigned courier name. Supports filtering by delivery status. Requires `ADMIN` role.',
+  })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    enum: ['CREATED', 'ASSIGNED', 'IN_TRANSIT', 'COMPLETED'],
+    description: 'Filter deliveries by status. Omit to return all statuses.',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Page number (1-based). Defaults to 1.',
+    example: 1,
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Maximum results per page. Defaults to 20, max 100.',
+    example: 20,
+  })
+  @ApiOkResponse({
+    description:
+      'Paginated list of deliveries with recipient and courier details.',
+    type: DeliveriesListResponse,
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
+  @ApiForbiddenResponse({ description: 'Requires ADMIN role.' })
   async handle(
     @Query(new ZodValidationPipe(fetchDeliveriesQuerySchema))
     query: FetchDeliveriesQuerySchema,

--- a/src/infra/http/controllers/delivery/recipient/create-recipient-address.controller.ts
+++ b/src/infra/http/controllers/delivery/recipient/create-recipient-address.controller.ts
@@ -16,6 +16,20 @@ import {
   GeocodingConfigurationError,
   GeocodingInvalidResponseError,
 } from '@/domain/delivery/application/use-cases/errors/geocoding-service-error'
+import {
+  ApiBadGatewayResponse,
+  ApiBearerAuth,
+  ApiBody,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiInternalServerErrorResponse,
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger'
+import { RecipientAddressDto } from '../../../swagger/dtos/recipient/recipient-address.dto'
 
 const createRecipientAddressBodySchema = z.object({
   street: z.string(),
@@ -32,6 +46,8 @@ type CreateRecipientAddressBodySchema = z.infer<
   typeof createRecipientAddressBodySchema
 >
 
+@ApiTags('Recipients')
+@ApiBearerAuth('JWT')
 @Controller()
 export class CreateRecipientAddressController {
   constructor(
@@ -40,6 +56,32 @@ export class CreateRecipientAddressController {
 
   @Post('/recipients/:recipientId/addresses')
   @Roles('ADMIN')
+  @ApiOperation({
+    summary: 'Add an address to a recipient',
+    description:
+      'Create a new delivery address for the specified recipient. The address is automatically geocoded via Nominatim/OpenStreetMap on creation, storing `latitude` and `longitude` for proximity queries. Requires `ADMIN` role.',
+  })
+  @ApiParam({
+    name: 'recipientId',
+    format: 'uuid',
+    description: 'ID of the recipient to add the address to.',
+  })
+  @ApiBody({ type: RecipientAddressDto })
+  @ApiCreatedResponse({
+    description: 'Address created and geocoded successfully.',
+  })
+  @ApiNotFoundResponse({
+    description: 'No recipient found with the provided recipientId.',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Geocoding service configuration error.',
+  })
+  @ApiBadGatewayResponse({
+    description:
+      'Geocoding service returned an invalid or unparseable response.',
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
+  @ApiForbiddenResponse({ description: 'Requires ADMIN role.' })
   async handle(
     @Param('recipientId') recipientId: string,
     @Body(new ZodValidationPipe(createRecipientAddressBodySchema))

--- a/src/infra/http/controllers/delivery/recipient/create-recipient.controller.ts
+++ b/src/infra/http/controllers/delivery/recipient/create-recipient.controller.ts
@@ -10,6 +10,17 @@ import { ZodValidationPipe } from '../../../pipes/zod-validation-pipe'
 import { Roles } from '@/infra/auth/roles.decorator'
 import { CreateRecipientUseCase } from '@/domain/delivery/application/use-cases/recipient/create-recipient'
 import { IdentificationType } from '@/domain/delivery/enterprise/entities/value-objects/identity-document'
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiBody,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger'
+import { CreateRecipientDto } from '../../../swagger/dtos/recipient/create-recipient.dto'
 
 const createRecipientBodySchema = z.object({
   name: z.string(),
@@ -22,6 +33,8 @@ const createRecipientBodySchema = z.object({
 
 type CreateRecipientBodySchema = z.infer<typeof createRecipientBodySchema>
 
+@ApiTags('Recipients')
+@ApiBearerAuth('JWT')
 @Controller()
 @UsePipes(new ZodValidationPipe(createRecipientBodySchema))
 export class CreateRecipientController {
@@ -29,6 +42,18 @@ export class CreateRecipientController {
 
   @Post('/recipients')
   @Roles('ADMIN')
+  @ApiOperation({
+    summary: 'Create a recipient',
+    description:
+      "Register a new recipient with a primary identity document. The identity document is used later during delivery completion to verify the receiver's identity. Requires `ADMIN` role.",
+  })
+  @ApiBody({ type: CreateRecipientDto })
+  @ApiCreatedResponse({ description: 'Recipient created successfully.' })
+  @ApiBadRequestResponse({
+    description: 'Invalid request body or validation error.',
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
+  @ApiForbiddenResponse({ description: 'Requires ADMIN role.' })
   async handle(@Body() body: CreateRecipientBodySchema) {
     const { name, identityDocument } = body
 

--- a/src/infra/http/controllers/delivery/recipient/delete-recipient-address.controller.ts
+++ b/src/infra/http/controllers/delivery/recipient/delete-recipient-address.controller.ts
@@ -9,7 +9,20 @@ import {
 import { Roles } from '@/infra/auth/roles.decorator'
 import { DeleteRecipientAddressUseCase } from '@/domain/delivery/application/use-cases/recipient/delete-recipient-address'
 import { RecipientAddressNotFoundError } from '@/domain/delivery/application/use-cases/recipient/errors/recipient-address-not-found-error'
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger'
 
+@ApiTags('Recipients')
+@ApiBearerAuth('JWT')
 @Controller()
 export class DeleteRecipientAddressController {
   constructor(
@@ -19,6 +32,29 @@ export class DeleteRecipientAddressController {
   @Delete('/recipients/:recipientId/addresses/:addressId')
   @Roles('ADMIN')
   @HttpCode(204)
+  @ApiOperation({
+    summary: 'Delete a recipient address',
+    description:
+      'Permanently remove a delivery address from a recipient. Requires `ADMIN` role.',
+  })
+  @ApiParam({
+    name: 'recipientId',
+    format: 'uuid',
+    description: 'ID of the recipient that owns the address.',
+  })
+  @ApiParam({
+    name: 'addressId',
+    format: 'uuid',
+    description: 'ID of the address to delete.',
+  })
+  @ApiNoContentResponse({ description: 'Address deleted successfully.' })
+  @ApiBadRequestResponse({ description: 'Invalid path parameters.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
+  @ApiForbiddenResponse({ description: 'Requires ADMIN role.' })
+  @ApiNotFoundResponse({
+    description:
+      'No address found with the provided addressId for this recipient.',
+  })
   async handle(
     @Param('recipientId') recipientId: string,
     @Param('addressId') addressId: string,

--- a/src/infra/http/controllers/delivery/recipient/fetch-recipient-addresses.controller.ts
+++ b/src/infra/http/controllers/delivery/recipient/fetch-recipient-addresses.controller.ts
@@ -2,7 +2,20 @@ import { BadRequestException, Controller, Get, Param } from '@nestjs/common'
 import { Roles } from '@/infra/auth/roles.decorator'
 import { FetchRecipientAddressesUseCase } from '@/domain/delivery/application/use-cases/recipient/fetch-recipient-addresses'
 import { RecipientAddressPresenter } from '@/infra/http/presenters/recipient-address-presenter'
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger'
+import { AddressesListResponse } from '../../../swagger/responses/addresses-list.response'
 
+@ApiTags('Recipients')
+@ApiBearerAuth('JWT')
 @Controller()
 export class FetchRecipientAddressesController {
   constructor(
@@ -11,6 +24,23 @@ export class FetchRecipientAddressesController {
 
   @Get('/recipients/:recipientId/addresses')
   @Roles('ADMIN')
+  @ApiOperation({
+    summary: 'List addresses for a recipient',
+    description:
+      'Return all delivery addresses registered for the specified recipient, including geocoded coordinates. Requires `ADMIN` role.',
+  })
+  @ApiParam({
+    name: 'recipientId',
+    format: 'uuid',
+    description: 'ID of the recipient whose addresses to retrieve.',
+  })
+  @ApiOkResponse({
+    description: 'List of addresses for the recipient.',
+    type: AddressesListResponse,
+  })
+  @ApiBadRequestResponse({ description: 'Invalid recipientId.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
+  @ApiForbiddenResponse({ description: 'Requires ADMIN role.' })
   async handle(@Param('recipientId') recipientId: string) {
     const result = await this.fetchRecipientAddressesUseCase.execute({
       recipientId,

--- a/src/infra/http/controllers/delivery/recipient/update-recipient-address.controller.ts
+++ b/src/infra/http/controllers/delivery/recipient/update-recipient-address.controller.ts
@@ -17,6 +17,20 @@ import {
   GeocodingConfigurationError,
   GeocodingInvalidResponseError,
 } from '@/domain/delivery/application/use-cases/errors/geocoding-service-error'
+import {
+  ApiBadGatewayResponse,
+  ApiBearerAuth,
+  ApiBody,
+  ApiForbiddenResponse,
+  ApiInternalServerErrorResponse,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger'
+import { RecipientAddressDto } from '../../../swagger/dtos/recipient/recipient-address.dto'
 
 const updateRecipientAddressBodySchema = z.object({
   street: z.string(),
@@ -33,6 +47,8 @@ type UpdateRecipientAddressBodySchema = z.infer<
   typeof updateRecipientAddressBodySchema
 >
 
+@ApiTags('Recipients')
+@ApiBearerAuth('JWT')
 @Controller()
 export class UpdateRecipientAddressController {
   constructor(
@@ -42,6 +58,38 @@ export class UpdateRecipientAddressController {
   @Put('/recipients/:recipientId/addresses/:addressId')
   @Roles('ADMIN')
   @HttpCode(204)
+  @ApiOperation({
+    summary: 'Update a recipient address',
+    description:
+      'Replace all fields of an existing recipient address. The address is re-geocoded on every update, refreshing the stored `latitude` and `longitude`. Requires `ADMIN` role.',
+  })
+  @ApiParam({
+    name: 'recipientId',
+    format: 'uuid',
+    description: 'ID of the recipient that owns the address.',
+  })
+  @ApiParam({
+    name: 'addressId',
+    format: 'uuid',
+    description: 'ID of the address to update.',
+  })
+  @ApiBody({ type: RecipientAddressDto })
+  @ApiNoContentResponse({
+    description: 'Address updated and re-geocoded successfully.',
+  })
+  @ApiNotFoundResponse({
+    description:
+      'No address found with the provided addressId for this recipient.',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Geocoding service configuration error.',
+  })
+  @ApiBadGatewayResponse({
+    description:
+      'Geocoding service returned an invalid or unparseable response.',
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
+  @ApiForbiddenResponse({ description: 'Requires ADMIN role.' })
   async handle(
     @Param('recipientId') recipientId: string,
     @Param('addressId') addressId: string,

--- a/src/infra/http/controllers/identity/authenticate.controller.ts
+++ b/src/infra/http/controllers/identity/authenticate.controller.ts
@@ -11,6 +11,16 @@ import { ZodValidationPipe } from '../../pipes/zod-validation-pipe'
 import { Public } from '@/infra/auth/public'
 import { AuthenticateUseCase } from '@/domain/identity/application/use-cases/authenticate'
 import { InvalidCredentialsError } from '@/domain/identity/application/use-cases/errors/invalid-credentials-error'
+import {
+  ApiBadRequestResponse,
+  ApiBody,
+  ApiCreatedResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger'
+import { AuthenticateDto } from '../../swagger/dtos/identity/authenticate.dto'
+import { AccessTokenResponse } from '../../swagger/responses/access-token.response'
 
 const authenticateBodySchema = z.object({
   email: z.string().email(),
@@ -19,6 +29,7 @@ const authenticateBodySchema = z.object({
 
 type AuthenticateBodySchema = z.infer<typeof authenticateBodySchema>
 
+@ApiTags('Identity')
 @Controller()
 @Public()
 @UsePipes(new ZodValidationPipe(authenticateBodySchema))
@@ -26,6 +37,20 @@ export class AuthenticateController {
   constructor(private authenticateUseCase: AuthenticateUseCase) {}
 
   @Post('/sessions')
+  @ApiOperation({
+    summary: 'Authenticate',
+    description:
+      'Sign in with email and password to receive a short-lived RS256-signed JWT access token. Use the token in the `Authorization: Bearer <token>` header for all protected endpoints.',
+  })
+  @ApiBody({ type: AuthenticateDto })
+  @ApiCreatedResponse({
+    description: 'Authentication successful.',
+    type: AccessTokenResponse,
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid request body or validation error.',
+  })
+  @ApiUnauthorizedResponse({ description: 'Email or password is incorrect.' })
   async handle(@Body() body: AuthenticateBodySchema) {
     const { email, password } = body
 

--- a/src/infra/http/controllers/identity/change-password.controller.ts
+++ b/src/infra/http/controllers/identity/change-password.controller.ts
@@ -10,6 +10,16 @@ import z from 'zod'
 import { ZodValidationPipe } from '../../pipes/zod-validation-pipe'
 import { InvalidCredentialsError } from '@/domain/identity/application/use-cases/errors/invalid-credentials-error'
 import { ChangePasswordUseCase } from '@/domain/identity/application/use-cases/change-password'
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiBody,
+  ApiCreatedResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger'
+import { ChangePasswordDto } from '../../swagger/dtos/identity/change-password.dto'
 
 const changePasswordBodySchema = z.object({
   email: z.string().email(),
@@ -21,12 +31,27 @@ const changePasswordBodySchema = z.object({
 
 type ChangePasswordBodySchema = z.infer<typeof changePasswordBodySchema>
 
+@ApiTags('Identity')
+@ApiBearerAuth('JWT')
 @Controller()
 @UsePipes(new ZodValidationPipe(changePasswordBodySchema))
 export class ChangePasswordController {
   constructor(private changePasswordUseCase: ChangePasswordUseCase) {}
 
   @Post('/change-password')
+  @ApiOperation({
+    summary: 'Change password',
+    description:
+      'Update the password for the authenticated account. Both the JWT token and the current password are required as a double-verification measure for this sensitive operation.',
+  })
+  @ApiBody({ type: ChangePasswordDto })
+  @ApiCreatedResponse({ description: 'Password changed successfully.' })
+  @ApiBadRequestResponse({
+    description: 'Invalid request body or validation error.',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Missing or invalid JWT token, or incorrect current password.',
+  })
   async handle(@Body() body: ChangePasswordBodySchema) {
     const { email, password, newPassword } = body
 

--- a/src/infra/http/controllers/identity/create-account.controller.ts
+++ b/src/infra/http/controllers/identity/create-account.controller.ts
@@ -11,6 +11,15 @@ import {
 import z from 'zod'
 import { ZodValidationPipe } from '../../pipes/zod-validation-pipe'
 import { Public } from '@/infra/auth/public'
+import {
+  ApiBody,
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiBadRequestResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger'
+import { CreateAccountDto } from '../../swagger/dtos/identity/create-account.dto'
 
 const createAccountBodySchema = z.object({
   email: z.string().email(),
@@ -20,6 +29,7 @@ const createAccountBodySchema = z.object({
 
 type CreateAccountBodySchema = z.infer<typeof createAccountBodySchema>
 
+@ApiTags('Identity')
 @Controller()
 @Public()
 @UsePipes(new ZodValidationPipe(createAccountBodySchema))
@@ -27,6 +37,19 @@ export class CreateAccountController {
   constructor(private createAccountUseCase: CreateAccountUseCase) {}
 
   @Post('/accounts')
+  @ApiOperation({
+    summary: 'Create an account',
+    description:
+      'Register a new account with either an `ADMIN` or `WORKER` role. The role defaults to `WORKER` if omitted. This endpoint is public and does not require authentication.',
+  })
+  @ApiBody({ type: CreateAccountDto })
+  @ApiCreatedResponse({ description: 'Account created successfully.' })
+  @ApiBadRequestResponse({
+    description: 'Invalid request body or validation error.',
+  })
+  @ApiConflictResponse({
+    description: 'An account with this email address already exists.',
+  })
   async handle(@Body() body: CreateAccountBodySchema) {
     const { email, password, role } = body
 

--- a/src/infra/http/swagger/dtos/courier/complete-delivery.dto.ts
+++ b/src/infra/http/swagger/dtos/courier/complete-delivery.dto.ts
@@ -1,0 +1,77 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+
+export class CompleteDeliveryDto {
+  @ApiProperty({
+    example: 'Jane Smith',
+    description: 'Full name of the person who physically received the package.',
+  })
+  receivedByName: string
+
+  @ApiPropertyOptional({
+    example: 'AB-123456',
+    description:
+      'Document number of the receiver. At least one of `receivedByDocument` or `proofImageUrl` must be provided.',
+  })
+  receivedByDocument?: string
+
+  @ApiProperty({
+    enum: [
+      'RECIPIENT',
+      'FAMILY_MEMBER',
+      'DOORMAN',
+      'RECEPTIONIST',
+      'NEIGHBOR',
+      'OTHER',
+    ],
+    example: 'RECIPIENT',
+    description:
+      'Relationship of the receiver to the original recipient. When the value is not `RECIPIENT`, the `notes` field becomes required.',
+  })
+  recipientRelationship:
+    | 'RECIPIENT'
+    | 'FAMILY_MEMBER'
+    | 'DOORMAN'
+    | 'RECEPTIONIST'
+    | 'NEIGHBOR'
+    | 'OTHER'
+
+  @ApiProperty({
+    enum: ['DOCUMENT', 'PHOTO', 'SIGNATURE', 'MANUAL'],
+    example: 'PHOTO',
+    description: 'Type of evidence used to confirm delivery.',
+  })
+  proofType: 'DOCUMENT' | 'PHOTO' | 'SIGNATURE' | 'MANUAL'
+
+  @ApiPropertyOptional({
+    example: 'https://cdn.fastfeet.com/proofs/delivery-abc123.jpg',
+    format: 'uri',
+    description:
+      'URL of an externally stored proof image. At least one of `proofImageUrl` or `receivedByDocument` must be provided.',
+  })
+  proofImageUrl?: string
+
+  @ApiPropertyOptional({
+    example: 40.7128,
+    description:
+      "Courier's latitude at the time of delivery. Optional — system records `UNAVAILABLE` location status when omitted.",
+    minimum: -90,
+    maximum: 90,
+  })
+  latitude?: number
+
+  @ApiPropertyOptional({
+    example: -74.006,
+    description:
+      "Courier's longitude at the time of delivery. Optional — system records `UNAVAILABLE` location status when omitted.",
+    minimum: -180,
+    maximum: 180,
+  })
+  longitude?: number
+
+  @ApiPropertyOptional({
+    example: 'Package left with building doorman on the ground floor.',
+    description:
+      'Required when `recipientRelationship` is not `RECIPIENT`. Provides context about the delivery handoff.',
+  })
+  notes?: string
+}

--- a/src/infra/http/swagger/dtos/courier/register-courier.dto.ts
+++ b/src/infra/http/swagger/dtos/courier/register-courier.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+export class RegisterCourierDto {
+  @ApiProperty({
+    example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    format: 'uuid',
+    description:
+      'ID of the WORKER account to be linked to this courier profile. The account must exist and have the WORKER role.',
+  })
+  accountId: string
+
+  @ApiProperty({
+    example: 'John Carter',
+    description: 'Full name of the courier.',
+  })
+  name: string
+}

--- a/src/infra/http/swagger/dtos/delivery/assign-courier.dto.ts
+++ b/src/infra/http/swagger/dtos/delivery/assign-courier.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+export class AssignCourierDto {
+  @ApiProperty({
+    example: 'c3d4e5f6-a7b8-9012-cdef-123456789012',
+    format: 'uuid',
+    description:
+      'ID of the courier to assign. The delivery status will be transitioned from `CREATED` to `ASSIGNED`.',
+  })
+  courierId: string
+}

--- a/src/infra/http/swagger/dtos/delivery/create-delivery.dto.ts
+++ b/src/infra/http/swagger/dtos/delivery/create-delivery.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+export class CreateDeliveryDto {
+  @ApiProperty({
+    example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    format: 'uuid',
+    description: 'ID of the recipient for this delivery.',
+  })
+  recipientId: string
+
+  @ApiProperty({
+    example: 'b2c3d4e5-f6a7-8901-bcde-f12345678901',
+    format: 'uuid',
+    description:
+      'ID of the specific recipient address to deliver to. Must belong to the specified recipient.',
+  })
+  recipientAddressId: string
+}

--- a/src/infra/http/swagger/dtos/identity/authenticate.dto.ts
+++ b/src/infra/http/swagger/dtos/identity/authenticate.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+export class AuthenticateDto {
+  @ApiProperty({
+    example: 'admin@fastfeet.com',
+    description: 'Email address of the account.',
+  })
+  email: string
+
+  @ApiProperty({
+    example: 'securepass123',
+    description: 'Account password.',
+  })
+  password: string
+}

--- a/src/infra/http/swagger/dtos/identity/change-password.dto.ts
+++ b/src/infra/http/swagger/dtos/identity/change-password.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+export class ChangePasswordDto {
+  @ApiProperty({
+    example: 'courier@fastfeet.com',
+    description: 'Email address of the account whose password will be changed.',
+  })
+  email: string
+
+  @ApiProperty({
+    example: 'currentpass123',
+    description: 'Current account password, required for verification.',
+  })
+  password: string
+
+  @ApiProperty({
+    example: 'newsecurepass456',
+    description: 'New password. Minimum 8 characters.',
+    minLength: 8,
+  })
+  newPassword: string
+}

--- a/src/infra/http/swagger/dtos/identity/create-account.dto.ts
+++ b/src/infra/http/swagger/dtos/identity/create-account.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+
+export class CreateAccountDto {
+  @ApiProperty({
+    example: 'courier@fastfeet.com',
+    description: 'A valid email address — must be unique across all accounts.',
+  })
+  email: string
+
+  @ApiProperty({
+    example: 'securepass123',
+    description: 'Account password. Minimum 8 characters.',
+    minLength: 8,
+  })
+  password: string
+
+  @ApiPropertyOptional({
+    enum: ['ADMIN', 'WORKER'],
+    default: 'WORKER',
+    description:
+      'Account role. `ADMIN` can manage the platform; `WORKER` is the courier role. Defaults to `WORKER`.',
+  })
+  role?: 'ADMIN' | 'WORKER'
+}

--- a/src/infra/http/swagger/dtos/recipient/create-recipient.dto.ts
+++ b/src/infra/http/swagger/dtos/recipient/create-recipient.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+class IdentityDocumentDto {
+  @ApiProperty({
+    enum: ['PERSONAL_ID', 'TAX_ID', 'PASSPORT', 'COMPANY_ID', 'OTHER'],
+    example: 'TAX_ID',
+    description:
+      'Document type. `PERSONAL_ID` for national IDs, `TAX_ID` for tax/fiscal IDs (e.g. NIF, EIN, SSN), `PASSPORT` for travel documents.',
+  })
+  type: 'PERSONAL_ID' | 'TAX_ID' | 'PASSPORT' | 'COMPANY_ID' | 'OTHER'
+
+  @ApiProperty({
+    example: '123-45-6789',
+    description: 'Document number as it appears on the physical document.',
+  })
+  number: string
+
+  @ApiProperty({
+    example: 'US',
+    description:
+      'ISO 3166-1 alpha-2 country code of the country that issued the document.',
+    pattern: '^[A-Z]{2}$',
+  })
+  issuingCountry: string
+}
+
+export class CreateRecipientDto {
+  @ApiProperty({
+    example: 'Alice Johnson',
+    description: 'Full name of the recipient.',
+  })
+  name: string
+
+  @ApiProperty({
+    type: IdentityDocumentDto,
+    description:
+      "Recipient's primary identity document. Used for verification when completing a delivery.",
+  })
+  identityDocument: IdentityDocumentDto
+}

--- a/src/infra/http/swagger/dtos/recipient/recipient-address.dto.ts
+++ b/src/infra/http/swagger/dtos/recipient/recipient-address.dto.ts
@@ -1,0 +1,53 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+
+export class RecipientAddressDto {
+  @ApiProperty({
+    example: 'Baker Street',
+    description: 'Street name.',
+  })
+  street: string
+
+  @ApiProperty({
+    example: '123',
+    description: 'Building or house number.',
+  })
+  number: string
+
+  @ApiProperty({
+    example: 'Midtown',
+    description: 'Neighborhood or district.',
+  })
+  neighborhood: string
+
+  @ApiPropertyOptional({
+    example: 'Apt 4B',
+    description:
+      'Additional address detail such as apartment, suite, or floor number.',
+  })
+  complement?: string
+
+  @ApiProperty({
+    example: 'New York',
+    description: 'City.',
+  })
+  city: string
+
+  @ApiProperty({
+    example: 'NY',
+    description: 'State or province abbreviation.',
+  })
+  state: string
+
+  @ApiProperty({
+    example: 'United States',
+    description: 'Country name.',
+  })
+  country: string
+
+  @ApiProperty({
+    example: '10001',
+    description:
+      'Postal or ZIP code. Used together with the other address fields for geocoding.',
+  })
+  postalCode: string
+}

--- a/src/infra/http/swagger/responses/access-token.response.ts
+++ b/src/infra/http/swagger/responses/access-token.response.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+export class AccessTokenResponse {
+  @ApiProperty({
+    example:
+      'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1dWlkLWhlcmUiLCJyb2xlIjoiV09SS0VSIiwiaWF0IjoxNjE2MjM5MDIyfQ.signature',
+    description:
+      'RS256-signed JWT access token. Include it in subsequent requests as `Authorization: Bearer <token>`.',
+  })
+  access_token: string
+}

--- a/src/infra/http/swagger/responses/addresses-list.response.ts
+++ b/src/infra/http/swagger/responses/addresses-list.response.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { RecipientAddressResponse } from './recipient-address.response'
+
+export class AddressesListResponse {
+  @ApiProperty({ type: [RecipientAddressResponse] })
+  addresses: RecipientAddressResponse[]
+}

--- a/src/infra/http/swagger/responses/courier-deliveries-list.response.ts
+++ b/src/infra/http/swagger/responses/courier-deliveries-list.response.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { CourierDeliveryDetailsResponse } from './courier-delivery-details.response'
+
+export class CourierDeliveriesListResponse {
+  @ApiProperty({ type: [CourierDeliveryDetailsResponse] })
+  deliveries: CourierDeliveryDetailsResponse[]
+}

--- a/src/infra/http/swagger/responses/courier-delivery-details.response.ts
+++ b/src/infra/http/swagger/responses/courier-delivery-details.response.ts
@@ -1,0 +1,37 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+
+export class CourierDeliveryDetailsResponse {
+  @ApiProperty({
+    example: 'e5f6a7b8-c9d0-1234-efgh-345678901234',
+    format: 'uuid',
+  })
+  id: string
+
+  @ApiProperty({
+    example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    format: 'uuid',
+  })
+  recipientId: string
+
+  @ApiProperty({ example: 'Alice Johnson' })
+  recipientName: string
+
+  @ApiProperty({
+    enum: ['CREATED', 'ASSIGNED', 'IN_TRANSIT', 'COMPLETED'],
+    example: 'IN_TRANSIT',
+    description:
+      'Current delivery status. Lifecycle: `CREATED → ASSIGNED → IN_TRANSIT → COMPLETED`.',
+  })
+  status: string
+
+  @ApiProperty({ example: '2024-03-15T10:30:00.000Z', format: 'date-time' })
+  createdAt: Date
+
+  @ApiPropertyOptional({
+    example: '2024-03-15T14:00:00.000Z',
+    format: 'date-time',
+    nullable: true,
+    type: Date,
+  })
+  updatedAt: Date | null
+}

--- a/src/infra/http/swagger/responses/deliveries-list.response.ts
+++ b/src/infra/http/swagger/responses/deliveries-list.response.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { DeliveryDetailsResponse } from './delivery-details.response'
+
+export class DeliveriesListResponse {
+  @ApiProperty({ type: [DeliveryDetailsResponse] })
+  deliveries: DeliveryDetailsResponse[]
+}

--- a/src/infra/http/swagger/responses/delivery-details.response.ts
+++ b/src/infra/http/swagger/responses/delivery-details.response.ts
@@ -1,0 +1,63 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+
+export class DeliveryDetailsResponse {
+  @ApiProperty({
+    example: 'e5f6a7b8-c9d0-1234-efgh-345678901234',
+    format: 'uuid',
+    description: 'Unique delivery identifier.',
+  })
+  id: string
+
+  @ApiProperty({
+    example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    format: 'uuid',
+  })
+  recipientId: string
+
+  @ApiPropertyOptional({
+    example: 'c3d4e5f6-a7b8-9012-cdef-123456789012',
+    format: 'uuid',
+    nullable: true,
+    type: String,
+    description:
+      'ID of the assigned courier. `null` when the delivery has not been assigned yet.',
+  })
+  courierId: string | null
+
+  @ApiProperty({
+    example: 'Alice Johnson',
+    description: 'Full name of the recipient.',
+  })
+  recipientName: string
+
+  @ApiPropertyOptional({
+    example: 'John Carter',
+    nullable: true,
+    type: String,
+    description:
+      'Full name of the assigned courier. `null` when no courier is assigned.',
+  })
+  courierName: string | null
+
+  @ApiProperty({
+    enum: ['CREATED', 'ASSIGNED', 'IN_TRANSIT', 'COMPLETED'],
+    example: 'ASSIGNED',
+    description:
+      'Current delivery status. Lifecycle: `CREATED → ASSIGNED → IN_TRANSIT → COMPLETED`.',
+  })
+  status: string
+
+  @ApiProperty({
+    example: '2024-03-15T10:30:00.000Z',
+    format: 'date-time',
+  })
+  createdAt: Date
+
+  @ApiPropertyOptional({
+    example: '2024-03-15T14:00:00.000Z',
+    format: 'date-time',
+    nullable: true,
+    type: Date,
+  })
+  updatedAt: Date | null
+}

--- a/src/infra/http/swagger/responses/recipient-address.response.ts
+++ b/src/infra/http/swagger/responses/recipient-address.response.ts
@@ -1,0 +1,39 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+
+export class RecipientAddressResponse {
+  @ApiProperty({
+    example: 'd4e5f6a7-b8c9-0123-defg-234567890123',
+    format: 'uuid',
+  })
+  id: string
+
+  @ApiProperty({
+    example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    format: 'uuid',
+  })
+  recipientId: string
+
+  @ApiProperty({ example: 'Baker Street' })
+  street: string
+
+  @ApiProperty({ example: '123' })
+  number: string
+
+  @ApiProperty({ example: 'Midtown' })
+  neighborhood: string
+
+  @ApiPropertyOptional({ example: 'Apt 4B', nullable: true, type: String })
+  complement: string | null
+
+  @ApiProperty({ example: 'New York' })
+  city: string
+
+  @ApiProperty({ example: 'NY' })
+  state: string
+
+  @ApiProperty({ example: 'United States' })
+  country: string
+
+  @ApiProperty({ example: '10001' })
+  postalCode: string
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,8 @@ import {
   NestFastifyApplication,
 } from '@nestjs/platform-fastify'
 import { EnvService } from './infra/env/env.service'
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
+import { apiReference } from '@scalar/nestjs-api-reference'
 
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(
@@ -14,6 +16,77 @@ async function bootstrap() {
 
   const configService = app.get(EnvService)
   const port = configService.get('PORT')
+
+  const config = new DocumentBuilder()
+    .setTitle('Fast Feet API')
+    .setDescription(
+      `REST API for managing the full lifecycle of package deliveries — from account creation and courier registration through recipient address geocoding to real-time nearby delivery queries based on geolocation.
+
+## Authentication
+
+Most endpoints require a Bearer JWT token. Authenticate via **POST /sessions** to obtain a token, then click **Authorize** and enter it as \`Bearer <token>\`.
+
+## Roles
+
+| Role | Description |
+|------|-------------|
+| \`ADMIN\` | Manages couriers, recipients, addresses, deliveries, and courier assignments |
+| \`WORKER\` | Courier role — can view and act on their own assigned deliveries |
+
+## Delivery Lifecycle
+
+\`\`\`
+CREATED → ASSIGNED → IN_TRANSIT → COMPLETED
+\`\`\`
+
+1. **CREATED** — Admin creates the delivery linked to a recipient address
+2. **ASSIGNED** — Admin assigns a courier (delivery becomes visible to the courier)
+3. **IN_TRANSIT** — Assigned courier picks up the package
+4. **COMPLETED** — Assigned courier submits proof of delivery`,
+    )
+    .setVersion('1.0.0')
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        description:
+          'RS256-signed JWT. Obtain a token from **POST /sessions** and enter it here as `Bearer <token>`.',
+      },
+      'JWT',
+    )
+    .addTag(
+      'Identity',
+      'Account registration, authentication, and password management',
+    )
+    .addTag(
+      'Couriers',
+      'Courier registration and courier-facing delivery operations',
+    )
+    .addTag('Recipients', 'Recipient management and address geocoding')
+    .addTag(
+      'Deliveries',
+      'Delivery creation, listing, assignment, and admin operations',
+    )
+    .build()
+
+  const documentFactory = () => SwaggerModule.createDocument(app, config)
+
+  SwaggerModule.setup('docs', app, documentFactory, {
+    jsonDocumentUrl: 'docs/json',
+    yamlDocumentUrl: 'docs/yaml',
+    swaggerUiEnabled: false,
+  })
+
+  app.use(
+    '/reference',
+    apiReference({
+      url: '/docs/json',
+      theme: 'deepSpace',
+      pageTitle: 'Fast Feet API — Documentation',
+      withFastify: true,
+    }),
+  )
 
   await app.listen(port, '0.0.0.0')
 }


### PR DESCRIPTION
## Description

Adds comprehensive OpenAPI 3.0 documentation for all REST endpoints using `@nestjs/swagger` and integrates Scalar API reference UI for interactive API exploration. Includes documented request/response DTOs, authentication flows, and role-based access annotations.

## Type of Change

- [x] Feature (new functionality)
- [ ] Bugfix (fixes an issue)
- [ ] Hotfix (critical fix for production)
- [ ] Refactor (code improvement without changing functionality)
- [ ] Documentation
- [ ] Chore (maintenance, dependencies, configs)

## Branch

- **Source:** `feature/swagger-scalar-docs`
- **Target:** `develop`

## Checklist

- [x] Code follows project standards
- [ ] Tests added/updated (if applicable)
- [x] Documentation updated (if applicable)
- [x] Self-reviewed the code