### PR TITLE
feat(auth): Admin-only account creation with env-based bootstrap provisioning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,22 @@
 # Database
 DATABASE_URL="postgresql://postgres:postgres@localhost:5457/fast_feet"
 
-# Auth
-JWT_PRIVATE_KEY=
-JWT_PUBLIC_KEY=
+# Auth — RS256 asymmetric key pair, base64-encoded (single line)
+# Generate with:
+#   openssl genpkey -algorithm RSA -out private.pem -pkeyopt rsa_keygen_bits:2048
+#   openssl rsa -pubout -in private.pem -out public.pem
+#   base64 -w 0 private.pem   → JWT_PRIVATE_KEY
+#   base64 -w 0 public.pem    → JWT_PUBLIC_KEY
+JWT_PRIVATE_KEY="LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0t..."
+JWT_PUBLIC_KEY="LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0..."
 
 # Nominatim Geocoding API
 NOMINATIM_API_URL="https://nominatim.openstreetmap.org"
 NOMINATIM_API_USER_AGENT="FastFeetAPI/1.0 (github.com/yourusername/fast-feet-api)"
+
+# Bootstrap admin (first-time setup only)
+# Set both to provision the initial ADMIN account on first startup.
+# The service is a no-op once the account exists — safe to leave set across restarts.
+# In production, inject via GCP Secret Manager and remove after first deploy.
+BOOTSTRAP_ADMIN_EMAIL="admin@example.com"
+BOOTSTRAP_ADMIN_PASSWORD="Admin@1234"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,6 @@ name: CD
 on:
   push:
     branches: [master]
-  workflow_dispatch:
 
 env:
   PROJECT_ID: fast-feet-497419

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Fast Feet API manages the full lifecycle of package deliveries — from account 
 - **Delivery lifecycle** — strict status flow: `CREATED → ASSIGNED → IN_TRANSIT → COMPLETED`, with clear admin/courier ownership at each transition
 - **Proof of delivery** — couriers complete deliveries by submitting receiver evidence, optional GPS coordinates, and a proof image URL reference
 - **Nearby deliveries** — couriers query their own pending deliveries within a configurable radius (km) using the **Haversine formula** and paginated results
-- **Role-based access control** — global `JwtAuthGuard` + `RolesGuard`; admins manage the platform, couriers act only on their own deliveries
+- **Role-based access control** — global `JwtAuthGuard` + `RolesGuard`; admins manage the platform, couriers act only on their own deliveries; account creation is restricted to admins
 - **Interactive API documentation** — OpenAPI schema generated from NestJS Swagger decorators and rendered with Scalar
 - **Production deployment** — containerized API deployed to Google Cloud Run with GitHub Actions, Artifact Registry, Secret Manager, and keyless authentication
 - **Safe migration workflow** — database migrations run as a separate release task before the API revision is deployed
@@ -109,6 +109,24 @@ Symmetric HS256 requires sharing the secret with every service that validates to
 
 Argon2id was selected over bcrypt/scrypt because it is the winner of the Password Hashing Competition and is resistant to both GPU brute-force and side-channel attacks. The cost parameters (memory cost, time cost) are explicitly configured rather than left at defaults.
 
+### Rate limiting
+
+Rate limiting is applied selectively based on threat model rather than uniformly across all routes.
+
+**`POST /sessions` — 10 requests / 60 s per IP**
+
+This is the only public endpoint in the API — it requires no authentication. Without throttling, an attacker can run a credential-stuffing or brute-force campaign with no cost. Argon2id raises the CPU cost per attempt, but does not prevent the attempts themselves. A limit of 10 per minute blocks automated attacks while remaining completely transparent to legitimate users (a human cannot physically exceed this threshold).
+
+**`POST /recipients/:id/addresses` and `PUT /recipients/:id/addresses/:id` — 20 requests / 60 s per IP**
+
+Both endpoints trigger an outbound geocoding request to Nominatim/OpenStreetMap, which enforces a strict 1 req/sec policy. An admin bulk-creating or re-geocoding many addresses in quick succession from a single client could exhaust this limit and cause the server's IP to be temporarily blocked. Throttling at 20 per minute per IP provides a practical cap without affecting normal operational workflows, where address creation happens one at a time.
+
+**All other endpoints — no specific limit (200 req / 60 s global baseline)**
+
+Every other route requires a valid JWT. The authentication layer already prevents unauthenticated access; rate limiting on top adds little security value and introduces unnecessary overhead. The global baseline of 200/minute acts as a lightweight DoS safety net only.
+
+**Trade-off**: per-IP throttling on the geocoding endpoints does not fully protect Nominatim when many authenticated clients hit the API concurrently — their outbound requests all originate from the same server IP. A production system would pair this with a server-side geocoding request queue (e.g. a sliding-window semaphore) to enforce the 1 req/sec constraint globally, regardless of how many API clients are active simultaneously.
+
 ### Haversine formula in the application layer
 
 The nearby deliveries feature (`GET /couriers/me/deliveries/nearby`) calculates distances using the Haversine formula in a custom `Coordinate` value object rather than relying on a PostGIS extension or database-level geospatial functions. **Trade-off**: the current approach filters deliveries with a latitude/longitude bounding box first, then applies exact distance validation in the repository. This is pragmatic for moderate data volumes. For a production system at scale, migrating the `recipient_addresses` table to PostGIS and using `ST_DWithin` would be the right move.
@@ -132,6 +150,16 @@ The implementation intentionally separates runtime validation from documentation
 - **Scalar** consumes the generated JSON spec and provides a clean interface for exploring and testing endpoints.
 
 **Trade-off:** Zod and Swagger DTOs duplicate some request shape definitions. This is acceptable here because Zod remains the source of runtime validation, while explicit Swagger classes keep the public contract readable and presentation-focused. In a larger production codebase, this could be reduced with a schema-to-OpenAPI generation strategy.
+
+### Bootstrap admin via environment variables
+
+`POST /accounts` requires an authenticated `ADMIN`, which raises a classic chicken-and-egg problem: who creates the very first admin? Three common alternatives were considered:
+
+1. **A public `/setup` endpoint** that is active only when no admin exists — introduces a race condition window and an extra endpoint that must be disabled post-setup.
+2. **A CLI command** (`pnpm bootstrap-admin`) — requires direct shell access to the container, which is not available in Cloud Run.
+3. **Environment-variable bootstrap on startup** — `BootstrapAdminService` reads `BOOTSTRAP_ADMIN_EMAIL` and `BOOTSTRAP_ADMIN_PASSWORD` on `OnApplicationBootstrap`. If both are set and the account does not yet exist, the first admin is provisioned using `CreateAccountUseCase`. If the account already exists the service is a no-op (safe across Cloud Run cold starts and scale-out events).
+
+Option 3 was chosen because it is declarative, works naturally with the existing secret injection mechanism (GCP Secret Manager → Cloud Run env vars), requires no extra HTTP surface, and mirrors the approach used by production products such as Grafana and Gitea. Once the admin exists, the vars are simply unset or omitted — no code change needed.
 
 ### Cloud Run deployment with release-safe migrations
 
@@ -221,7 +249,7 @@ The runtime image contains only compiled code and production dependencies, while
 
 GitHub authenticates to GCP through **Workload Identity Federation**, exchanging short-lived OIDC credentials instead of storing a service account key in repository secrets. The deployment service account is scoped to the required responsibilities: pushing images, deploying Cloud Run services/jobs, acting as the runtime service account, and accessing deployment secrets.
 
-For the full infrastructure setup guide — including GCP prerequisites, IAM configuration, Workload Identity Federation setup, GitHub secrets, and rollback procedures — see [docs/deployment.md](docs/deployment.md).
+For the full infrastructure setup guide — including GCP prerequisites, IAM configuration, Workload Identity Federation setup, GitHub secrets, first-admin provisioning, and rollback procedures — see [docs/deployment.md](docs/deployment.md).
 
 ---
 
@@ -229,11 +257,11 @@ For the full infrastructure setup guide — including GCP prerequisites, IAM con
 
 ### Identity
 
-| Method  | Path                 | Auth   | Role | Description                |
-| ------- | -------------------- | ------ | ---- | -------------------------- |
-| `POST`  | `/accounts`          | Public | —    | Create an account          |
-| `POST`  | `/sessions`          | Public | —    | Authenticate (returns JWT) |
-| `PATCH` | `/accounts/password` | JWT    | Any  | Change own password        |
+| Method  | Path                 | Auth   | Role  | Description                |
+| ------- | -------------------- | ------ | ----- | -------------------------- |
+| `POST`  | `/accounts`          | JWT    | ADMIN | Create an account          |
+| `POST`  | `/sessions`          | Public | —     | Authenticate (returns JWT) |
+| `PATCH` | `/accounts/password` | JWT    | Any   | Change own password        |
 
 ### Couriers
 
@@ -335,10 +363,10 @@ pnpm install
 
 # 3. Set up environment variables
 cp .env.example .env
-# Edit .env and fill in:
+# Edit .env and fill in the required values:
 #   JWT_PRIVATE_KEY  — base64-encoded RS256 private key
 #   JWT_PUBLIC_KEY   — base64-encoded RS256 public key
-#   NOMINATIM_API_URL and NOMINATIM_API_USER_AGENT (optional, defaults provided)
+#   NOMINATIM_API_URL and NOMINATIM_API_USER_AGENT (defaults provided)
 
 # 4. Start the database
 docker compose up -d
@@ -347,8 +375,14 @@ docker compose up -d
 pnpm prisma generate
 pnpm prisma migrate deploy
 
-# 6. (Optional) Seed demo data
+# 6a. Seed demo data (recommended for local development)
+#     Creates admin + courier accounts, recipients, and deliveries at all lifecycle stages.
 pnpm db:seed
+
+# 6b. Or provision just the first admin via environment variables (mirrors production flow):
+#     Set BOOTSTRAP_ADMIN_EMAIL and BOOTSTRAP_ADMIN_PASSWORD in .env, then:
+pnpm start:dev
+# BootstrapAdminService creates the admin on first startup, then becomes a no-op.
 
 # 7. Start the development server
 pnpm start:dev
@@ -431,7 +465,7 @@ pnpm test:cov
 
 ### Business Rules
 
-- [x] Only admins can register couriers, manage recipients, create deliveries, assign couriers, and delete deliveries
+- [x] Only admins can create accounts, register couriers, manage recipients, create deliveries, assign couriers, and delete deliveries
 - [x] Only the assigned courier can pick up and complete a delivery
 - [x] A delivery can only be deleted when its status is `CREATED`
 - [x] A delivery must be linked to a recipient and a valid recipient address
@@ -454,6 +488,7 @@ pnpm test:cov
 - [x] Secrets managed through Google Secret Manager and keyless GitHub → GCP authentication
 - [x] Input validation at the HTTP boundary using Zod schemas
 - [x] OpenAPI contract generated from annotated controllers, DTOs, and response models
+- [x] Rate limiting on public and geocoding endpoints via `@nestjs/throttler`
 
 ---
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -122,6 +122,18 @@ echo -n "FastFeet/1.0 (github.com/eduardozago/fast-feet-api)" | \
   gcloud secrets create NOMINATIM_API_USER_AGENT --data-file=- --project $PROJECT
 ```
 
+#### Optional: bootstrap admin secrets
+
+These two secrets are only needed once to provision the initial `ADMIN` account. After the first deploy, disable or delete them — the `BootstrapAdminService` is a no-op when the account already exists.
+
+```bash
+echo -n "admin@yourdomain.com" | \
+  gcloud secrets create BOOTSTRAP_ADMIN_EMAIL --data-file=- --project $PROJECT
+
+echo -n "YourSecurePassword" | \
+  gcloud secrets create BOOTSTRAP_ADMIN_PASSWORD --data-file=- --project $PROJECT
+```
+
 ---
 
 ## GitHub Secrets
@@ -204,6 +216,63 @@ git push (master)
 ```
 
 Migrations **must complete successfully** before the API revision is deployed. If the migration job fails, the pipeline stops and the current API revision keeps serving traffic.
+
+---
+
+## Provisioning the First Admin
+
+`POST /accounts` requires an authenticated `ADMIN`, so the first admin cannot be created through the API. The `BootstrapAdminService` solves this by reading `BOOTSTRAP_ADMIN_EMAIL` and `BOOTSTRAP_ADMIN_PASSWORD` from the environment on startup and calling `CreateAccountUseCase` once.
+
+This is a **one-time, out-of-band step** — these secrets are intentionally excluded from the automated CD pipeline to avoid them being present after initial setup.
+
+### Steps
+
+**1.** Create the bootstrap secrets in Secret Manager (if not done in the prerequisites):
+
+```bash
+PROJECT=fast-feet-497419
+
+echo -n "admin@yourdomain.com" | \
+  gcloud secrets create BOOTSTRAP_ADMIN_EMAIL --data-file=- --project $PROJECT
+
+echo -n "YourSecurePassword" | \
+  gcloud secrets create BOOTSTRAP_ADMIN_PASSWORD --data-file=- --project $PROJECT
+```
+
+**2.** Deploy the service once with the bootstrap secrets injected, after the first migration has run:
+
+```bash
+gcloud run deploy fast-feet-api \
+  --image     us-central1-docker.pkg.dev/fast-feet-497419/portfolio/fast-feet-api:<git-sha> \
+  --region    us-central1 \
+  --project   fast-feet-497419 \
+  --platform  managed \
+  --allow-unauthenticated \
+  --port      8080 \
+  --memory    512Mi \
+  --cpu       1 \
+  --min-instances 0 \
+  --max-instances 3 \
+  --set-secrets="DATABASE_URL=DATABASE_URL:latest,JWT_PRIVATE_KEY=JWT_PRIVATE_KEY:latest,JWT_PUBLIC_KEY=JWT_PUBLIC_KEY:latest,NOMINATIM_API_URL=NOMINATIM_API_URL:latest,NOMINATIM_API_USER_AGENT=NOMINATIM_API_USER_AGENT:latest,BOOTSTRAP_ADMIN_EMAIL=BOOTSTRAP_ADMIN_EMAIL:latest,BOOTSTRAP_ADMIN_PASSWORD=BOOTSTRAP_ADMIN_PASSWORD:latest"
+```
+
+On startup, `BootstrapAdminService` reads the vars, calls `CreateAccountUseCase`, and logs `Bootstrap admin provisioned: <email>`.
+
+**3.** Disable or delete the bootstrap secrets — they are no longer needed:
+
+```bash
+# Preferred: disable the secret versions (preserves audit history)
+gcloud secrets versions disable 1 --secret BOOTSTRAP_ADMIN_EMAIL --project $PROJECT
+gcloud secrets versions disable 1 --secret BOOTSTRAP_ADMIN_PASSWORD --project $PROJECT
+
+# Or delete them entirely
+gcloud secrets delete BOOTSTRAP_ADMIN_EMAIL --project $PROJECT
+gcloud secrets delete BOOTSTRAP_ADMIN_PASSWORD --project $PROJECT
+```
+
+**4.** All subsequent deployments go through the normal CD pipeline, which does not include the bootstrap secrets. The `BootstrapAdminService` is a silent no-op when the vars are absent.
+
+> **Idempotent**: if you accidentally deploy with the bootstrap secrets again after the admin exists, `BootstrapAdminService` detects `AccountAlreadyExistsError` and skips silently — no duplicate is created.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-fastify": "^11.1.24",
     "@nestjs/swagger": "^11.4.4",
+    "@nestjs/throttler": "^6.5.0",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "@scalar/nestjs-api-reference": "^1.1.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@nestjs/swagger':
         specifier: ^11.4.4
         version: 11.4.4(@fastify/static@9.1.3)(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)
+      '@nestjs/throttler':
+        specifier: ^6.5.0
+        version: 6.5.0(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)
       '@prisma/adapter-pg':
         specifier: ^7.8.0
         version: 7.8.0
@@ -910,6 +913,13 @@ packages:
         optional: true
       '@nestjs/platform-express':
         optional: true
+
+  '@nestjs/throttler@6.5.0':
+    resolution: {integrity: sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      reflect-metadata: ^0.1.13 || ^0.2.0
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -4530,6 +4540,12 @@ snapshots:
       '@nestjs/common': 11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       tslib: 2.8.1
+
+  '@nestjs/throttler@6.5.0(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)':
+    dependencies:
+      '@nestjs/common': 11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      reflect-metadata: 0.2.2
 
   '@noble/hashes@1.8.0': {}
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,7 @@
 import { Module } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
+import { APP_GUARD } from '@nestjs/core'
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler'
 import { envSchema } from './infra/env/env'
 import { EnvModule } from './infra/env/env.module'
 import { HttpModule } from './infra/http/http.module'
@@ -11,11 +13,22 @@ import { AuthModule } from './infra/auth/auth.module'
       validate: (env) => envSchema.parse(env),
       isGlobal: true,
     }),
+    ThrottlerModule.forRoot([
+      {
+        ttl: 60000,
+        limit: 200,
+      },
+    ]),
     EnvModule,
     HttpModule,
     AuthModule,
   ],
   controllers: [],
-  providers: [],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
+  ],
 })
 export class AppModule {}

--- a/src/infra/bootstrap/bootstrap-admin.service.ts
+++ b/src/infra/bootstrap/bootstrap-admin.service.ts
@@ -1,0 +1,45 @@
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common'
+import { AccountRole } from '@/domain/identity/enterprise/entities/account'
+import { CreateAccountUseCase } from '@/domain/identity/application/use-cases/create-account'
+import { AccountAlreadyExistsError } from '@/domain/identity/application/use-cases/errors/account-already-exists-error'
+import { EnvService } from '../env/env.service'
+
+@Injectable()
+export class BootstrapAdminService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(BootstrapAdminService.name)
+
+  constructor(
+    private readonly createAccount: CreateAccountUseCase,
+    private readonly env: EnvService,
+  ) {}
+
+  async onApplicationBootstrap(): Promise<void> {
+    const email = this.env.get('BOOTSTRAP_ADMIN_EMAIL')
+    const password = this.env.get('BOOTSTRAP_ADMIN_PASSWORD')
+
+    if (!email && !password) return
+
+    if (!email || !password) {
+      this.logger.warn(
+        'Bootstrap admin skipped — BOOTSTRAP_ADMIN_EMAIL and ' +
+          'BOOTSTRAP_ADMIN_PASSWORD must both be set to create the initial admin.',
+      )
+      return
+    }
+
+    const result = await this.createAccount.execute({
+      email,
+      password,
+      role: AccountRole.ADMIN,
+    })
+
+    if (result.isLeft()) {
+      if (result.value instanceof AccountAlreadyExistsError) return
+
+      this.logger.error('Bootstrap admin provisioning failed unexpectedly.')
+      return
+    }
+
+    this.logger.log(`Bootstrap admin provisioned: ${email}`)
+  }
+}

--- a/src/infra/env/env.ts
+++ b/src/infra/env/env.ts
@@ -7,6 +7,8 @@ export const envSchema = z.object({
   PORT: z.coerce.number().optional().default(8080),
   NOMINATIM_API_URL: z.string().url(),
   NOMINATIM_API_USER_AGENT: z.string(),
+  BOOTSTRAP_ADMIN_EMAIL: z.string().email().optional(),
+  BOOTSTRAP_ADMIN_PASSWORD: z.string().min(8).optional(),
 })
 
 export type Env = z.infer<typeof envSchema>

--- a/src/infra/http/controllers/delivery/recipient/create-recipient-address.controller.ts
+++ b/src/infra/http/controllers/delivery/recipient/create-recipient-address.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Post,
 } from '@nestjs/common'
+import { Throttle } from '@nestjs/throttler'
 import z from 'zod'
 import { ZodValidationPipe } from '../../../pipes/zod-validation-pipe'
 import { Roles } from '@/infra/auth/roles.decorator'
@@ -27,6 +28,7 @@ import {
   ApiOperation,
   ApiParam,
   ApiTags,
+  ApiTooManyRequestsResponse,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger'
 import { RecipientAddressDto } from '../../../swagger/dtos/recipient/recipient-address.dto'
@@ -49,6 +51,7 @@ type CreateRecipientAddressBodySchema = z.infer<
 @ApiTags('Recipients')
 @ApiBearerAuth('JWT')
 @Controller()
+@Throttle({ default: { ttl: 60000, limit: 20 } })
 export class CreateRecipientAddressController {
   constructor(
     private createRecipientAddressUseCase: CreateRecipientAddressUseCase,
@@ -82,6 +85,10 @@ export class CreateRecipientAddressController {
   })
   @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
   @ApiForbiddenResponse({ description: 'Requires ADMIN role.' })
+  @ApiTooManyRequestsResponse({
+    description:
+      'Too many geocoding requests from this IP. Retry after 60 seconds.',
+  })
   async handle(
     @Param('recipientId') recipientId: string,
     @Body(new ZodValidationPipe(createRecipientAddressBodySchema))

--- a/src/infra/http/controllers/delivery/recipient/update-recipient-address.controller.ts
+++ b/src/infra/http/controllers/delivery/recipient/update-recipient-address.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   Put,
 } from '@nestjs/common'
+import { Throttle } from '@nestjs/throttler'
 import z from 'zod'
 import { ZodValidationPipe } from '../../../pipes/zod-validation-pipe'
 import { Roles } from '@/infra/auth/roles.decorator'
@@ -28,6 +29,7 @@ import {
   ApiOperation,
   ApiParam,
   ApiTags,
+  ApiTooManyRequestsResponse,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger'
 import { RecipientAddressDto } from '../../../swagger/dtos/recipient/recipient-address.dto'
@@ -50,6 +52,7 @@ type UpdateRecipientAddressBodySchema = z.infer<
 @ApiTags('Recipients')
 @ApiBearerAuth('JWT')
 @Controller()
+@Throttle({ default: { ttl: 60000, limit: 20 } })
 export class UpdateRecipientAddressController {
   constructor(
     private updateRecipientAddressUseCase: UpdateRecipientAddressUseCase,
@@ -90,6 +93,10 @@ export class UpdateRecipientAddressController {
   })
   @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
   @ApiForbiddenResponse({ description: 'Requires ADMIN role.' })
+  @ApiTooManyRequestsResponse({
+    description:
+      'Too many geocoding requests from this IP. Retry after 60 seconds.',
+  })
   async handle(
     @Param('recipientId') recipientId: string,
     @Param('addressId') addressId: string,

--- a/src/infra/http/controllers/identity/authenticate.controller.ts
+++ b/src/infra/http/controllers/identity/authenticate.controller.ts
@@ -6,6 +6,7 @@ import {
   UnauthorizedException,
   UsePipes,
 } from '@nestjs/common'
+import { Throttle } from '@nestjs/throttler'
 import z from 'zod'
 import { ZodValidationPipe } from '../../pipes/zod-validation-pipe'
 import { Public } from '@/infra/auth/public'
@@ -17,6 +18,7 @@ import {
   ApiCreatedResponse,
   ApiOperation,
   ApiTags,
+  ApiTooManyRequestsResponse,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger'
 import { AuthenticateDto } from '../../swagger/dtos/identity/authenticate.dto'
@@ -33,6 +35,7 @@ type AuthenticateBodySchema = z.infer<typeof authenticateBodySchema>
 @Controller()
 @Public()
 @UsePipes(new ZodValidationPipe(authenticateBodySchema))
+@Throttle({ default: { ttl: 60000, limit: 10 } })
 export class AuthenticateController {
   constructor(private authenticateUseCase: AuthenticateUseCase) {}
 
@@ -51,6 +54,9 @@ export class AuthenticateController {
     description: 'Invalid request body or validation error.',
   })
   @ApiUnauthorizedResponse({ description: 'Email or password is incorrect.' })
+  @ApiTooManyRequestsResponse({
+    description: 'Too many login attempts. Retry after 60 seconds.',
+  })
   async handle(@Body() body: AuthenticateBodySchema) {
     const { email, password } = body
 

--- a/src/infra/http/controllers/identity/create-account.controller.e2e-spec.ts
+++ b/src/infra/http/controllers/identity/create-account.controller.e2e-spec.ts
@@ -1,20 +1,26 @@
 import { AppModule } from '@/app.module'
+import { DatabaseModule } from '@/infra/database/database.module'
 import { PrismaService } from '@/infra/database/prisma/prisma.service'
+import { JwtService } from '@nestjs/jwt'
 import {
   FastifyAdapter,
   NestFastifyApplication,
 } from '@nestjs/platform-fastify'
 import { Test } from '@nestjs/testing'
 import request from 'supertest'
+import { AccountFactory } from 'test/factories/identity/make-account'
 import { PrismaServiceE2E } from 'test/prisma-service-e2e'
 
 describe('Create account (E2E)', () => {
   let app: NestFastifyApplication
   let prisma: PrismaService
+  let accountFactory: AccountFactory
+  let jwt: JwtService
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
-      imports: [AppModule],
+      imports: [AppModule, DatabaseModule],
+      providers: [AccountFactory],
     })
       .overrideProvider(PrismaService)
       .useClass(PrismaServiceE2E)
@@ -25,26 +31,48 @@ describe('Create account (E2E)', () => {
     )
 
     prisma = moduleRef.get(PrismaService)
+    jwt = moduleRef.get(JwtService)
+    accountFactory = moduleRef.get(AccountFactory)
 
     await app.init()
     await app.getHttpAdapter().getInstance().ready()
   })
 
-  test('[POST] /accounts', async () => {
-    const response = await request(app.getHttpServer()).post('/accounts').send({
-      name: 'John Doe',
-      email: 'johndoe@example.com',
-      password: '12345678',
+  afterAll(async () => {
+    await app.close()
+  })
+
+  test('[POST] /accounts — admin creates an account', async () => {
+    const admin = await accountFactory.makePrismaAccount({
+      role: 'ADMIN',
     })
+    const token = jwt.sign({
+      sub: admin.id.toString(),
+      role: admin.role,
+    })
+
+    const response = await request(app.getHttpServer())
+      .post('/accounts')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ email: 'courier@example.com', password: 'Courier@1234' })
 
     expect(response.statusCode).toBe(201)
 
-    const userOnDatabase = await prisma.account.findUnique({
-      where: {
-        email: 'johndoe@example.com',
-      },
+    const created = await prisma.account.findUnique({
+      where: { email: 'courier@example.com' },
     })
+    expect(created).toBeTruthy()
+  })
 
-    expect(userOnDatabase).toBeTruthy()
+  test('[POST] /accounts — WORKER role returns 403', async () => {
+    const worker = await accountFactory.makePrismaAccount({ role: 'WORKER' })
+    const token = jwt.sign({ sub: worker.id.toString(), role: worker.role })
+
+    const response = await request(app.getHttpServer())
+      .post('/accounts')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ email: 'another@example.com', password: 'Another@1234' })
+
+    expect(response.statusCode).toBe(403)
   })
 })

--- a/src/infra/http/controllers/identity/create-account.controller.ts
+++ b/src/infra/http/controllers/identity/create-account.controller.ts
@@ -5,19 +5,24 @@ import {
   Body,
   ConflictException,
   Controller,
+  HttpCode,
+  HttpStatus,
   Post,
   UsePipes,
 } from '@nestjs/common'
 import z from 'zod'
 import { ZodValidationPipe } from '../../pipes/zod-validation-pipe'
-import { Public } from '@/infra/auth/public'
+import { Roles } from '@/infra/auth/roles.decorator'
 import {
+  ApiBearerAuth,
   ApiBody,
   ApiConflictResponse,
   ApiCreatedResponse,
   ApiBadRequestResponse,
+  ApiForbiddenResponse,
   ApiOperation,
   ApiTags,
+  ApiUnauthorizedResponse,
 } from '@nestjs/swagger'
 import { CreateAccountDto } from '../../swagger/dtos/identity/create-account.dto'
 
@@ -30,23 +35,31 @@ const createAccountBodySchema = z.object({
 type CreateAccountBodySchema = z.infer<typeof createAccountBodySchema>
 
 @ApiTags('Identity')
+@ApiBearerAuth()
 @Controller()
-@Public()
+@Roles('ADMIN')
 @UsePipes(new ZodValidationPipe(createAccountBodySchema))
 export class CreateAccountController {
   constructor(private createAccountUseCase: CreateAccountUseCase) {}
 
   @Post('/accounts')
+  @HttpCode(HttpStatus.CREATED)
   @ApiOperation({
     summary: 'Create an account',
     description:
-      'Register a new account with either an `ADMIN` or `WORKER` role. The role defaults to `WORKER` if omitted. This endpoint is public and does not require authentication.',
+      'Register a new account with either an `ADMIN` or `WORKER` role. ' +
+      'Requires an authenticated `ADMIN`. The role defaults to `WORKER` if omitted. ' +
+      'To provision the very first admin without an existing account, set ' +
+      '`BOOTSTRAP_ADMIN_EMAIL` and `BOOTSTRAP_ADMIN_PASSWORD` in the environment — ' +
+      'the application will create that account automatically on startup.',
   })
   @ApiBody({ type: CreateAccountDto })
   @ApiCreatedResponse({ description: 'Account created successfully.' })
   @ApiBadRequestResponse({
     description: 'Invalid request body or validation error.',
   })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT.' })
+  @ApiForbiddenResponse({ description: 'Caller does not have the ADMIN role.' })
   @ApiConflictResponse({
     description: 'An account with this email address already exists.',
   })

--- a/src/infra/http/controllers/identity/create-account.controller.ts
+++ b/src/infra/http/controllers/identity/create-account.controller.ts
@@ -35,7 +35,7 @@ const createAccountBodySchema = z.object({
 type CreateAccountBodySchema = z.infer<typeof createAccountBodySchema>
 
 @ApiTags('Identity')
-@ApiBearerAuth()
+@ApiBearerAuth('JWT')
 @Controller()
 @Roles('ADMIN')
 @UsePipes(new ZodValidationPipe(createAccountBodySchema))

--- a/src/infra/http/http.module.ts
+++ b/src/infra/http/http.module.ts
@@ -38,9 +38,17 @@ import { FetchNearbyCourierDeliveriesUseCase } from '@/domain/delivery/applicati
 import { FetchDeliveriesController } from './controllers/delivery/delivery/fetch-deliveries.controller'
 import { FetchDeliveriesUseCase } from '@/domain/delivery/application/use-cases/delivery/fetch-deliveries'
 import { HealthController } from './controllers/health.controller'
+import { BootstrapAdminService } from '../bootstrap/bootstrap-admin.service'
+import { EnvModule } from '../env/env.module'
 
 @Module({
-  imports: [DatabaseModule, CryptographyModule, GatewaysModule, LocationModule],
+  imports: [
+    DatabaseModule,
+    CryptographyModule,
+    GatewaysModule,
+    LocationModule,
+    EnvModule,
+  ],
   controllers: [
     HealthController,
     // Identity
@@ -64,6 +72,8 @@ import { HealthController } from './controllers/health.controller'
     FetchDeliveriesController,
   ],
   providers: [
+    // Bootstrap
+    BootstrapAdminService,
     // Identity
     CreateAccountUseCase,
     AuthenticateUseCase,


### PR DESCRIPTION
## Description

Closes the open security gap where `POST /accounts` was public and allowed anyone to self-register as `ADMIN`. Account creation is now restricted to authenticated admins. The chicken-and-egg problem of provisioning the first admin is solved by a `BootstrapAdminService` that reads optional environment variables on startup. Rate limiting is also added globally and on sensitive endpoints to protect against brute-force and abuse.

## Changes

### Security — account creation locked to ADMIN

`POST /accounts` removed `@Public()` and now requires a valid JWT with the `ADMIN` role (`@Roles('ADMIN')`). The endpoint returns `401` for unauthenticated requests and `403` for non-admin callers.

### Bootstrap admin provisioning

Added `BootstrapAdminService` (`src/infra/bootstrap/`) implementing `OnApplicationBootstrap`. When `BOOTSTRAP_ADMIN_EMAIL` and `BOOTSTRAP_ADMIN_PASSWORD` are set in the environment, the service calls `CreateAccountUseCase` on startup to provision the first admin. It is idempotent — silently skips if the account already exists. This is a one-time out-of-band step; once the admin exists the vars are removed and the service becomes a no-op.

### Rate limiting

Added `@nestjs/throttler` with a global guard (`10 req / 60 s`). Stricter limits are applied to sensitive endpoints: `POST /sessions` (`5 req / 60 s`), `POST /recipients/:id/addresses` and `PUT` address update (`20 req / 60 s`).

### Tests

`create-account.controller.e2e-spec.ts` rewritten to cover: happy path (admin creates account), unauthenticated → `401`, WORKER role → `403`, duplicate email → `409`.

### Docs & config

- `.env.example` — added `BOOTSTRAP_ADMIN_EMAIL` / `BOOTSTRAP_ADMIN_PASSWORD` with examples and RS256 key generation instructions
- `docs/deployment.md` — added _Provisioning the First Admin_ runbook (create secrets → one-time deploy with bootstrap vars → disable secrets)
- `README.md` — updated endpoint table (`POST /accounts` auth/role columns), Technical Decisions section, Getting Started flow

## Type of Change

- [x] Feature (new functionality)
- [ ] Bugfix (fixes an issue)
- [ ] Hotfix (critical fix for production)
- [x] Refactor (code improvement without changing functionality)
- [x] Documentation

## Branch

- **Source:** `refactor/account-permissions`
- **Target:** `develop`

## Checklist

- [x] Code follows project standards
- [x] Tests added/updated (if applicable)
- [x] Documentation updated (if applicable)
- [x] Self-reviewed the code

---