### PR TITLE
fix(ci): use PAT to allow CD workflow to trigger on release events

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,5 +16,4 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          release-type: node
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
GITHUB_TOKEN suppresses all downstream workflow events, including release: [created]. Replacing it with a PAT (RELEASE_PLEASE_TOKEN) ensures cd.yml triggers automatically on every release.